### PR TITLE
L1: Add .gitattributes and normalize line endings (closes #18)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,51 @@
+# Default to text with LF line endings
+* text=auto eol=lf
+
+# Explicitly text
+*.ts            text eol=lf
+*.tsx           text eol=lf
+*.js            text eol=lf
+*.jsx           text eol=lf
+*.mjs           text eol=lf
+*.cjs           text eol=lf
+*.json          text eol=lf
+*.md            text eol=lf
+*.yml           text eol=lf
+*.yaml          text eol=lf
+*.css           text eol=lf
+*.html          text eol=lf
+*.sql           text eol=lf
+*.sh            text eol=lf
+*.txt           text eol=lf
+*.gitignore     text eol=lf
+*.gitattributes text eol=lf
+*.prettierignore text eol=lf
+*.prettierrc    text eol=lf
+*.eslintrc      text eol=lf
+*.gitkeep       text eol=lf
+LICENSE         text eol=lf
+README*         text eol=lf
+
+# Binary — never normalize
+*.png           binary
+*.jpg           binary
+*.jpeg          binary
+*.gif           binary
+*.ico           binary
+*.pdf           binary
+*.zip           binary
+*.tar.gz        binary
+*.db            binary
+*.sqlite        binary
+*.node          binary
+*.exe           binary
+*.dll           binary
+*.so            binary
+*.dylib         binary
+*.map           binary
+
+# bin/ — engine ships binaries (MediaInfo CLI) here; treat as binary
+packages/engine/bin/**  binary
+
+# Generated lockfiles — keep LF but don't munge
+package-lock.json text eol=lf


### PR DESCRIPTION
## Summary

Pre-MR for the FileOrganizer quality-review work plan. Adds `.gitattributes`
with `* text=auto eol=lf` plus explicit binary overrides, and applies
`git add --renormalize .` so the repo baseline is LF-normalized.

After this merges, WSL2 (and any non-Windows) clones will no longer show
the ~33980-line CRLF/LF diff against tracked files that previously
contaminated every other diff.

## Test plan
- [ ] CI passes (typecheck, lint, test, build)
- [ ] Fresh WSL2 clone after merge: `git diff` is clean
- [ ] Fresh Windows clone after merge: `git diff` is clean (line endings stored as LF, working tree converted per local Git config or left as LF)
- [ ] No test depends on CRLF line endings

## Out of scope
No code behavior changes. No quality-review code-fix findings addressed here.

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)