### PR TITLE
B2: Unlink corrupt partial dest on cross-drive hash mismatch (closes #20)

### DIFF
--- a/packages/engine/src/organize/move-cross-drive.test.ts
+++ b/packages/engine/src/organize/move-cross-drive.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
   createHash,
 } from 'node:crypto';
@@ -10,6 +10,13 @@ import {
   rmSync,
   writeFileSync,
 } from 'node:fs';
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>();
+  return { ...actual };
+});
+
+import * as fsp from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { openCatalog, closeCatalog, type Catalog } from '../catalog/connection.js';
@@ -239,5 +246,66 @@ describe('moveCrossDrive', () => {
     expect(readFileSync(destPath, 'utf8')).toBe('a different file already here');
     const row = db.prepare(`SELECT path FROM files WHERE id = ?`).get(fileId) as { path: string };
     expect(row.path).toBe(expectedDest);
+  });
+
+  it('unlinks the corrupt partial dest before throwing on hash mismatch', async () => {
+    const sourceRoot = resolve(dir, 'SRC');
+    const destRoot = resolve(dir, 'DST');
+    const sourcePath = resolve(sourceRoot, 'b.jpg');
+    const destPath = resolve(destRoot, 'Photos', 'b.jpg');
+    // Seed file with real content but corrupt the catalog hash so the
+    // post-copy re-hash will never match.
+    const fileId = seedFile(sourcePath, 'real content', sourceDriveId);
+    db.prepare(`UPDATE files SET sha256 = ? WHERE id = ?`).run('z'.repeat(64), fileId);
+
+    await expect(
+      moveCrossDrive({
+        db,
+        fileId,
+        destPath,
+        destDriveId,
+        sourceDriveRoot: sourceRoot,
+        batchId,
+        chunkBytes: 64 * 1024,
+      }),
+    ).rejects.toBeInstanceOf(IntegrityError);
+
+    // The partially-written destination must have been removed.
+    expect(existsSync(destPath)).toBe(false);
+  });
+
+  it('propagates the original IntegrityError when the cleanup unlink also fails', async () => {
+    const sourceRoot = resolve(dir, 'SRC');
+    const destRoot = resolve(dir, 'DST');
+    const sourcePath = resolve(sourceRoot, 'c.jpg');
+    const destPath = resolve(destRoot, 'Photos', 'c.jpg');
+    const fileId = seedFile(sourcePath, 'real content 2', sourceDriveId);
+    db.prepare(`UPDATE files SET sha256 = ? WHERE id = ?`).run('z'.repeat(64), fileId);
+
+    // Make unlink fail with a secondary error (e.g. permission denied).
+    const unlinkSpy = vi
+      .spyOn(fsp, 'unlink')
+      .mockRejectedValueOnce(Object.assign(new Error('EPERM'), { code: 'EPERM' }));
+
+    let caught: unknown;
+    try {
+      await moveCrossDrive({
+        db,
+        fileId,
+        destPath,
+        destDriveId,
+        sourceDriveRoot: sourceRoot,
+        batchId,
+        chunkBytes: 64 * 1024,
+      });
+    } catch (err) {
+      caught = err;
+    }
+
+    unlinkSpy.mockRestore();
+
+    // The caller must see IntegrityError, not the EPERM from unlink.
+    expect(caught).toBeInstanceOf(IntegrityError);
+    expect((caught as IntegrityError).code).toBe('CROSS_DRIVE_HASH_MISMATCH');
   });
 });

--- a/packages/engine/src/organize/move-cross-drive.ts
+++ b/packages/engine/src/organize/move-cross-drive.ts
@@ -1,4 +1,5 @@
 import { createReadStream, createWriteStream, mkdirSync } from 'node:fs';
+import { unlink } from 'node:fs/promises';
 import { pipeline } from 'node:stream/promises';
 import { dirname } from 'node:path';
 import { DriveError, IntegrityError } from '@fileorganizer/shared';
@@ -77,6 +78,13 @@ export async function moveCrossDrive(input: MoveCrossDriveInput): Promise<MoveOu
     sleepMs: 0,
   });
   if (liveHash !== row.sha256) {
+    // Clean up corrupt partial dest; swallow secondary I/O failures so the
+    // original IntegrityError surfaces to the caller.
+    try {
+      await unlink(finalDestPath);
+    } catch {
+      // intentionally ignored
+    }
     throw new IntegrityError(
       'CROSS_DRIVE_HASH_MISMATCH',
       `dest hash ${liveHash} != catalog ${row.sha256}`,


### PR DESCRIPTION
## Summary

Fixes Blocker #20: when the post-copy hash check fails in `moveCrossDrive`,
the partial corrupt destination file is now unlinked before
`IntegrityError` is thrown, instead of being left on disk indefinitely.

## Implementation notes

- Unlink runs BEFORE the throw — this is cleanup of an intermediate
  corrupt file, not a reversal of FS-first ordering
- Wrapped in its own try/catch so a secondary I/O failure (e.g. file
  already removed) does not mask the original IntegrityError
- Uses async `unlink` from `node:fs/promises` consistent with the
  existing async function and the B1 precedent (readdirSync → async readdir)
- No change to the rest of the move pipeline

## Test plan

- [x] New test: hash mismatch triggers unlink — `existsSync(finalDestPath)` is false after the throw
- [x] New test: if `unlink` itself fails (mocked to reject with EPERM), the original `IntegrityError` still propagates (cleanup failure is silent)
- [x] Existing engine suite continues to pass (267 baseline → 269 with new tests)
- [x] Lint + typecheck pass

## Out of scope

- Quarantine reconciler scope (B1, merged in #37)
- Cross-drive undo state correctness (#27 / M7)
- Free-space pre-flight (#22 / M2)

Closes #20