### PR TITLE
M1: Catalog SQL safety and atomicity (closes #21)

### DIFF
--- a/packages/engine/src/catalog/files-repo.test.ts
+++ b/packages/engine/src/catalog/files-repo.test.ts
@@ -161,4 +161,50 @@ describe('FilesRepo', () => {
     repo.markMissing(driveId, newScanId, ['/x/foo']);
     expect(repo.findByPath(driveId, '/x/foobar/a.jpg')!.state).toBe('indexed');
   });
+
+  it('markMissing does not match sibling paths when scan root contains literal %', () => {
+    // /scan-root%/photo01.jpg would match /scan-root%1.jpg via unescaped LIKE
+    const repo = new FilesRepo(db);
+    // Target: file UNDER the scan root (contains %)
+    repo.upsertOne(input('/scan-root%/photo%1.jpg', 'h1', '2024-01-01T00:00:00.000Z'));
+    // Sibling: same prefix but NOT under the scan root
+    repo.upsertOne(input('/scan-root-other/photo%1.jpg', 'h2', '2024-01-01T00:00:00.000Z'));
+    // Plain file in sibling without wildcard chars - should also NOT be matched
+    repo.upsertOne(input('/scan-root-other/photo01.jpg', 'h3', '2024-01-01T00:00:00.000Z'));
+
+    const newScanId = 'test-scan-2';
+    db.prepare(
+      `INSERT INTO scans (id, drive_id, started_at, status, throttle_profile) VALUES (?, ?, ?, ?, ?)`,
+    ).run(newScanId, driveId, new Date().toISOString(), 'running', 'balanced');
+
+    // Only mark missing for /scan-root% (i.e. none of the files re-appear in new scan)
+    repo.markMissing(driveId, newScanId, ['/scan-root%']);
+
+    // The file under /scan-root% should be marked missing
+    expect(repo.findByPath(driveId, '/scan-root%/photo%1.jpg')!.state).toBe('missing');
+    // Siblings under /scan-root-other must NOT be marked missing
+    expect(repo.findByPath(driveId, '/scan-root-other/photo%1.jpg')!.state).toBe('indexed');
+    expect(repo.findByPath(driveId, '/scan-root-other/photo01.jpg')!.state).toBe('indexed');
+  });
+
+  it('markMissing does not match sibling paths when scan root contains literal _', () => {
+    // /scan-root_a/photo_a.jpg is under the root; /scan-root-other/photoxa.jpg should NOT match
+    const repo = new FilesRepo(db);
+    // File UNDER the scan root (contains _)
+    repo.upsertOne(input('/scan-root_a/photo_a.jpg', 'h1', '2024-01-01T00:00:00.000Z'));
+    // Sibling: different root that would match if _ were treated as LIKE wildcard
+    repo.upsertOne(input('/scan-root-other/photoxa.jpg', 'h2', '2024-01-01T00:00:00.000Z'));
+
+    const newScanId = 'test-scan-2';
+    db.prepare(
+      `INSERT INTO scans (id, drive_id, started_at, status, throttle_profile) VALUES (?, ?, ?, ?, ?)`,
+    ).run(newScanId, driveId, new Date().toISOString(), 'running', 'balanced');
+
+    repo.markMissing(driveId, newScanId, ['/scan-root_a']);
+
+    // File under /scan-root_a marked missing (not re-seen in new scan)
+    expect(repo.findByPath(driveId, '/scan-root_a/photo_a.jpg')!.state).toBe('missing');
+    // File under /scan-root-other must NOT be matched via _ wildcard
+    expect(repo.findByPath(driveId, '/scan-root-other/photoxa.jpg')!.state).toBe('indexed');
+  });
 });

--- a/packages/engine/src/catalog/files-repo.ts
+++ b/packages/engine/src/catalog/files-repo.ts
@@ -97,11 +97,15 @@ export class FilesRepo {
     const clauses: string[] = [];
     const params: (string | number)[] = [driveId, currentScanId];
     for (const raw of scanRoots) {
+      // Escape literal LIKE wildcards in the scan-root path so that `%` and `_`
+      // in folder names are not treated as SQL wildcards. ESCAPE '\\' is the
+      // SQLite convention for a backslash escape character.
       const trimmed = raw.replace(/[/\\]+$/, '');
-      clauses.push('path LIKE ?');
-      params.push(trimmed + '/%');
-      clauses.push('path LIKE ?');
-      params.push(trimmed + '\\%');
+      const escaped = trimmed.replace(/%/g, '\\%').replace(/_/g, '\\_');
+      clauses.push('path LIKE ? ESCAPE \'\\\'');
+      params.push(escaped + '/%');
+      clauses.push('path LIKE ? ESCAPE \'\\\'');
+      params.push(escaped + '\\%');
     }
     const sql = `UPDATE files SET state = 'missing'
        WHERE drive_id = ? AND scan_id != ? AND state = 'indexed'

--- a/packages/engine/src/catalog/reconcile.test.ts
+++ b/packages/engine/src/catalog/reconcile.test.ts
@@ -142,6 +142,62 @@ describe('reconcileOnStartup', () => {
   });
 });
 
+describe('reconcileOnStartup – atomicity', () => {
+  it('rolls back all op updates when a DB error occurs mid-loop', async () => {
+    // Insert a batch
+    db.prepare(
+      `INSERT INTO batches (id, kind, started_at, status, description, summary) VALUES (?, ?, ?, ?, ?, ?)`,
+    ).run('b-atomic', 'move', '2024-01-01T00:00:00Z', 'in-progress', 't', '{}');
+
+    // Insert 3 in-progress ops; none have matching filesystem files so all will resolve to 'failed'
+    const ids = [1, 2, 3].map((i) =>
+      insertOp({
+        batch_id: 'b-atomic',
+        kind: 'move',
+        source_path: join(dir, `gone${String(i)}`),
+        dest_path: join(dir, `also-gone${String(i)}`),
+        pre_hash: 'x',
+        post_hash: 'y',
+        status: 'in-progress',
+      }),
+    );
+
+    // Patch db.prepare so the 3rd UPDATE operations call throws — simulating a mid-loop crash.
+    // We wrap the real prepare and count UPDATE operations calls.
+    let updateOpsCallCount = 0;
+    const originalPrepare = db.prepare.bind(db);
+    const prepareStub = (sql: string) => {
+      const stmt = originalPrepare(sql);
+      if (sql.startsWith('UPDATE operations SET status')) {
+        updateOpsCallCount += 1;
+        if (updateOpsCallCount === 3) {
+          // Return a fake statement whose run() throws
+          return {
+            run: (..._args: unknown[]) => {
+              throw new Error('simulated DB crash on 3rd UPDATE');
+            },
+          } as unknown as ReturnType<typeof db.prepare>;
+        }
+      }
+      return stmt;
+    };
+    db.prepare = prepareStub as typeof db.prepare;
+
+    await expect(reconcileOnStartup(db)).rejects.toThrow('simulated DB crash');
+
+    // Restore real prepare
+    db.prepare = originalPrepare;
+
+    // All 3 ops must still be 'in-progress' — the transaction rolled back
+    for (const id of ids) {
+      const op = db.prepare(`SELECT status FROM operations WHERE id = ?`).get(id) as {
+        status: string;
+      };
+      expect(op.status).toBe('in-progress');
+    }
+  });
+});
+
 describe('reconcileOnStartup – quarantine orphan detection', () => {
   const QUARANTINE_DIR = '_FileOrganizer_quarantine';
 

--- a/packages/engine/src/catalog/reconcile.ts
+++ b/packages/engine/src/catalog/reconcile.ts
@@ -44,41 +44,57 @@ export async function reconcileOnStartup(db: Catalog): Promise<ReconcileResult> 
   let fixed = 0;
   let ambiguous = 0;
 
+  // Pre-compute all decisions before entering the synchronous DB transaction.
+  // better-sqlite3 transactions are sync-only, but decide() is async (file hashing).
+  // We process ops serially rather than in parallel to avoid overwhelming the
+  // filesystem with concurrent hash operations on large in-progress sets.
+  const decisions: Array<{ op: OpRow; decision: Decision }> = [];
   for (const op of ops) {
     const decision = await decide(op);
-    db.prepare(`UPDATE operations SET status = ?, error_message = ? WHERE id = ?`).run(
-      decision.status,
-      decision.message,
-      op.id,
-    );
+    decisions.push({ op, decision });
     if (decision.message.includes('ambiguous')) ambiguous += 1;
     else fixed += 1;
   }
 
-  const touchedBatches = db
-    .prepare(`SELECT id AS batch_id FROM batches WHERE status = 'in-progress'`)
-    .all() as Array<{ batch_id: string }>;
-
-  for (const { batch_id } of touchedBatches) {
-    const counts = db
-      .prepare(
-        `SELECT
-           SUM(CASE WHEN status IN ('pending','in-progress') THEN 1 ELSE 0 END) AS active,
-           SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END) AS failed,
-           COUNT(*) AS total
-         FROM operations WHERE batch_id = ?`,
-      )
-      .get(batch_id) as { active: number | null; failed: number | null; total: number | null };
-    if ((counts.total ?? 0) === 0) continue;
-    if ((counts.active ?? 0) === 0) {
-      const finalStatus = (counts.failed ?? 0) > 0 ? 'failed' : 'completed';
-      db.prepare(
-        `UPDATE batches SET status = ?, finished_at = ? WHERE id = ? AND status = 'in-progress'`,
-      ).run(finalStatus, new Date().toISOString(), batch_id);
+  // Apply all op updates and batch finalizations in a single atomic transaction.
+  // A mid-loop crash previously left a mix of updated and stale rows; wrapping
+  // both loops in one transaction gives all-or-nothing semantics so a restart
+  // re-processes the full set correctly.
+  db.transaction(() => {
+    for (const { op, decision } of decisions) {
+      db.prepare(`UPDATE operations SET status = ?, error_message = ? WHERE id = ?`).run(
+        decision.status,
+        decision.message,
+        op.id,
+      );
     }
-  }
 
-  // Quarantine-scope pass: detect files in _FileOrganizer_quarantine/ with no matching DB row
+    const touchedBatches = db
+      .prepare(`SELECT id AS batch_id FROM batches WHERE status = 'in-progress'`)
+      .all() as Array<{ batch_id: string }>;
+
+    for (const { batch_id } of touchedBatches) {
+      const counts = db
+        .prepare(
+          `SELECT
+             SUM(CASE WHEN status IN ('pending','in-progress') THEN 1 ELSE 0 END) AS active,
+             SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END) AS failed,
+             COUNT(*) AS total
+           FROM operations WHERE batch_id = ?`,
+        )
+        .get(batch_id) as { active: number | null; failed: number | null; total: number | null };
+      if ((counts.total ?? 0) === 0) continue;
+      if ((counts.active ?? 0) === 0) {
+        const finalStatus = (counts.failed ?? 0) > 0 ? 'failed' : 'completed';
+        db.prepare(
+          `UPDATE batches SET status = ?, finished_at = ? WHERE id = ? AND status = 'in-progress'`,
+        ).run(finalStatus, new Date().toISOString(), batch_id);
+      }
+    }
+  })();
+
+  // Quarantine-scope pass: detect files in _FileOrganizer_quarantine/ with no matching DB row.
+  // This is async filesystem I/O and must NOT be inside the synchronous DB transaction above.
   const quarantineOrphans = await detectQuarantineOrphans(db);
 
   return { scanned: ops.length, fixed, ambiguous, quarantineOrphans };

--- a/packages/engine/src/catalog/scans-repo.test.ts
+++ b/packages/engine/src/catalog/scans-repo.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -59,5 +59,26 @@ describe('ScansRepo', () => {
     expect(reloaded!.status).toBe('completed');
     expect(reloaded!.progress.filesIndexed).toBe(8);
     expect(reloaded!.stats.errors).toBe(0);
+  });
+
+  it('finish() does not call findById (no TOCTOU pre-read)', () => {
+    // After fixing the TOCTOU, finish() should perform a single atomic UPDATE
+    // without doing a SELECT first. We verify by spying on findById.
+    const repo = new ScansRepo(db);
+    const scan = repo.start({ driveId, rootPaths: ['/foo'], throttleProfile: 'balanced' });
+
+    const spy = vi.spyOn(repo, 'findById');
+    repo.finish(scan.id, 'completed', { errors: 3, filesIndexed: 5 });
+
+    // findById must NOT have been called inside finish()
+    expect(spy).not.toHaveBeenCalled();
+
+    // And the values from statsOverride must be stored
+    const reloaded = repo.findById(scan.id);
+    expect(reloaded!.status).toBe('completed');
+    expect(reloaded!.stats.errors).toBe(3);
+    expect(reloaded!.stats.filesIndexed).toBe(5);
+
+    spy.mockRestore();
   });
 });

--- a/packages/engine/src/catalog/scans-repo.ts
+++ b/packages/engine/src/catalog/scans-repo.ts
@@ -54,12 +54,22 @@ export class ScansRepo {
   }
 
   finish(id: string, status: ScanStatus, statsOverride: Partial<ScanStats>): void {
-    const existing = this.findById(id);
-    if (!existing) return;
-    const stats: ScanStats = { ...existing.progress, errors: 0, ...statsOverride };
+    // Merge stats atomically in a single UPDATE to eliminate the TOCTOU window
+    // that existed when finish() called findById() then UPDATE separately.
+    // SQLite json_patch(progress, override) merges the caller-supplied override
+    // onto the existing progress column in one statement — no pre-read needed.
+    // We apply two patches: first overlay {"errors":0} onto progress (so the
+    // baseline stats mirror the last progress snapshot), then overlay the
+    // caller's statsOverride to honour any explicit values.
     this.db
-      .prepare(`UPDATE scans SET status = ?, finished_at = ?, stats = ? WHERE id = ?`)
-      .run(status, new Date().toISOString(), JSON.stringify(stats), id);
+      .prepare(
+        `UPDATE scans
+            SET status = ?,
+                finished_at = ?,
+                stats = json_patch(json_patch(progress, '{"errors":0}'), ?)
+          WHERE id = ?`,
+      )
+      .run(status, new Date().toISOString(), JSON.stringify(statsOverride), id);
   }
 
   pause(id: string): void {

--- a/packages/engine/src/catalog/settings-repo.test.ts
+++ b/packages/engine/src/catalog/settings-repo.test.ts
@@ -60,4 +60,58 @@ describe('SettingsRepo', () => {
     expect(reloaded.uiPort).toBe(12345);
     expect(reloaded.recentArchiveCutoffYears).toBe(3);
   });
+
+  it('load() drops unknown keys that appear in the DB settings row', () => {
+    // Seed the DB with a settings row that contains an unknown key
+    const rowWithBogus = {
+      catalogVersion: 1,
+      categoryMap: DEFAULT_CATEGORY_MAP,
+      throttleProfiles: {},
+      throttleSchedule: [],
+      recentArchiveCutoffYears: 2,
+      uiPort: 0,
+      userExcluded: [],
+      bogusField: 'should-be-dropped',
+    };
+    db.prepare(`INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)`).run(
+      'settings',
+      JSON.stringify(rowWithBogus),
+    );
+
+    const s = new SettingsRepo(db).load();
+    // The returned object must not contain the unknown key
+    expect((s as unknown as Record<string, unknown>)['bogusField']).toBeUndefined();
+  });
+
+  it('load() + save() round-trip does not persist unknown keys', () => {
+    // Seed with an unknown key
+    const rowWithBogus = {
+      catalogVersion: 1,
+      categoryMap: DEFAULT_CATEGORY_MAP,
+      throttleProfiles: {},
+      throttleSchedule: [],
+      recentArchiveCutoffYears: 2,
+      uiPort: 7777,
+      userExcluded: [],
+      anotherBogusKey: 42,
+    };
+    db.prepare(`INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)`).run(
+      'settings',
+      JSON.stringify(rowWithBogus),
+    );
+
+    const repo = new SettingsRepo(db);
+    const loaded = repo.load();
+    // Save immediately (round-trip)
+    repo.save(loaded);
+
+    // Read raw JSON from DB and confirm unknown key is gone
+    const raw = db.prepare(`SELECT value FROM settings WHERE key = 'settings'`).get() as {
+      value: string;
+    };
+    const persisted = JSON.parse(raw.value) as Record<string, unknown>;
+    expect(persisted['anotherBogusKey']).toBeUndefined();
+    // Known key must still be present
+    expect(persisted['uiPort']).toBe(7777);
+  });
 });

--- a/packages/engine/src/catalog/settings-repo.ts
+++ b/packages/engine/src/catalog/settings-repo.ts
@@ -16,8 +16,40 @@ export class SettingsRepo {
       .prepare(`SELECT value FROM settings WHERE key = ?`)
       .get(KEY) as { value: string } | undefined;
     if (row) {
-      const loaded = JSON.parse(row.value) as Partial<Settings>;
-      return { ...this.defaults(), ...loaded };
+      // Explicitly destructure only known Settings keys so that unrecognised
+      // columns stored in the DB (e.g. from a future migration rollback) are
+      // dropped rather than accumulating in the in-memory shape and being
+      // re-serialised on the next save().
+      const loaded = JSON.parse(row.value) as Record<string, unknown>;
+      const defaults = this.defaults();
+      return {
+        catalogVersion:
+          typeof loaded['catalogVersion'] === 'number'
+            ? loaded['catalogVersion']
+            : defaults.catalogVersion,
+        categoryMap:
+          loaded['categoryMap'] != null
+            ? (loaded['categoryMap'] as Settings['categoryMap'])
+            : defaults.categoryMap,
+        throttleProfiles:
+          loaded['throttleProfiles'] != null
+            ? (loaded['throttleProfiles'] as Settings['throttleProfiles'])
+            : defaults.throttleProfiles,
+        throttleSchedule:
+          Array.isArray(loaded['throttleSchedule'])
+            ? (loaded['throttleSchedule'] as Settings['throttleSchedule'])
+            : defaults.throttleSchedule,
+        recentArchiveCutoffYears:
+          typeof loaded['recentArchiveCutoffYears'] === 'number'
+            ? loaded['recentArchiveCutoffYears']
+            : defaults.recentArchiveCutoffYears,
+        uiPort:
+          typeof loaded['uiPort'] === 'number' ? loaded['uiPort'] : defaults.uiPort,
+        userExcluded:
+          Array.isArray(loaded['userExcluded'])
+            ? (loaded['userExcluded'] as Settings['userExcluded'])
+            : defaults.userExcluded,
+      };
     }
     const fresh = this.defaults();
     this.save(fresh);


### PR DESCRIPTION
## Summary

Four independent catalog-layer correctness fixes bundled because they share the same subsystem and the same MR review effort:

1. **LIKE-escape for `markMissing`** — paths with literal `%`/`_` no longer match siblings via SQL wildcards; pre-escapes with `ESCAPE '\\'`
2. **`reconcileOnStartup` ops + batch loops wrapped in a single `db.transaction`** — B1's async quarantine scan stays outside (filesystem I/O must not block the sync transaction)
3. **`scans-repo.finish()` SELECT eliminated** — single atomic `UPDATE ... SET stats = json_patch(json_patch(progress, '{"errors":0}'), ?)` replaces the prior SELECT+UPDATE TOCTOU pair
4. **`settings-repo.load()` explicitly destructures known keys** — unknown columns from the DB no longer round-trip into the in-memory `Settings` shape

## Test plan

- [x] LIKE-escape: paths with `%` and `_` in scan root are correctly scoped (two new tests in `files-repo.test.ts`)
- [x] Reconcile atomicity: mid-loop DB error leaves all ops as `in-progress` (one new test in `reconcile.test.ts`)
- [x] `finish()`: spy confirms `findById` is not called; `stats` values from `statsOverride` are stored correctly (one new test in `scans-repo.test.ts`)
- [x] settings-repo: unknown DB key absent from `load()` output and not re-persisted on `save()` round-trip (two new tests in `settings-repo.test.ts`)
- [x] Full engine suite passes (275 tests); lint + typecheck clean

## Out of scope

- Other reconciler concerns (quarantine scope was B1, merged in #37)
- Free-space formula (M2 / #22)
- Other settings-repo concerns (N2 / #33 — subsumed by fix #4 in this PR)

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)