### PR TITLE
M2: Free-space safety margin uses freeBytes, not totalBytes (closes #22)

### DIFF
--- a/docs/superpowers/plans/2026-04-25-file-organizer-implementation.md
+++ b/docs/superpowers/plans/2026-04-25-file-organizer-implementation.md
@@ -9792,7 +9792,7 @@ for (const op of input.operations) {
 for (const [driveId, bytesNeeded] of bytesPerDrive) {
   const drive = driveById.get(driveId);
   if (!drive) continue;
-  const safetyMargin = Math.floor(drive.totalBytes * 0.05);
+  const safetyMargin = Math.floor(drive.freeBytes * 0.05);
   if (drive.freeBytes - safetyMargin < bytesNeeded) {
     new BatchesRepo(input.db).finish(batch.id, 'failed', { reason: 'insufficient free space' });
     throw new Error(`insufficient free space on ${drive.label}: need ${bytesNeeded} bytes, have ${drive.freeBytes - safetyMargin} bytes after 5% safety margin`);

--- a/packages/engine/src/organize/applier.test.ts
+++ b/packages/engine/src/organize/applier.test.ts
@@ -506,6 +506,254 @@ describe('applyApprovedBatch', () => {
     expect(ops).toHaveLength(0);
   });
 
+  it('Test A: allows batch on near-full disk when bytes needed fit within freeBytes-based safety margin', async () => {
+    // Drive: 1 TB total, 500 MB free. Batch needs 400 MB.
+    // Correct formula: safetyMargin = 500MB * 0.05 = 25MB, usable = 475MB, 400 <= 475 → ALLOWED
+    // Broken formula:  safetyMargin = 1TB  * 0.05 = 51GB, usable negative             → REJECTED
+    const drives = new DriveRepo(db);
+    const srcRoot = join(dir, 'src-a');
+    const dstRoot = join(dir, 'dst-a');
+    mkdirSync(srcRoot, { recursive: true });
+    mkdirSync(dstRoot, { recursive: true });
+
+    const TB = 1_000_000_000_000;
+    const MB = 1_000_000;
+
+    const srcId = drives.upsert({
+      volumeSerial: 'V-SRC-A',
+      label: 'SRC-A',
+      currentLetter: null,
+      mountPath: null,
+      kind: 'local',
+      roles: [],
+      totalBytes: TB,
+      freeBytes: TB,
+    }).id;
+    const dstId = drives.upsert({
+      volumeSerial: 'V-DST-A',
+      label: 'DST-A',
+      currentLetter: null,
+      mountPath: null,
+      kind: 'local',
+      roles: [],
+      totalBytes: TB,
+      freeBytes: 500 * MB,
+    }).id;
+    db.prepare(
+      `INSERT INTO scans (id, drive_id, started_at, status, throttle_profile) VALUES (?, ?, ?, ?, ?)`,
+    ).run('s-a', srcId, new Date().toISOString(), 'completed', 'balanced');
+
+    const srcPath = join(srcRoot, 'big.bin');
+    const bigContent = 'big-file-content';
+    writeFileSync(srcPath, bigContent);
+    new FilesRepo(db).upsertOne({
+      driveId: srcId,
+      path: srcPath,
+      name: 'big.bin',
+      extension: 'bin',
+      sizeBytes: Buffer.byteLength(bigContent),
+      category: 'image',
+      sha256: shaOf(bigContent),
+      mtime: '2024-01-01T00:00:00.000Z',
+      ctime: '2024-01-01T00:00:00.000Z',
+      exifDate: null,
+      dateSource: 'mtime',
+      width: null,
+      height: null,
+      durationSeconds: null,
+      ntfsFileId: null,
+      state: 'indexed',
+      scanId: 's-a',
+    });
+    const fileId = (db.prepare(`SELECT id FROM files WHERE path = ?`).get(srcPath) as { id: number }).id;
+
+    const planned: PlannedOperation[] = [
+      {
+        fileId,
+        ruleId: 'r-a',
+        sourceDriveId: srcId,
+        sourcePath: srcPath,
+        destDriveId: dstId,
+        destPath: join(dstRoot, 'big.bin'),
+        kind: 'cross-drive-move',
+        estimatedBytes: 400 * MB,
+      },
+    ];
+
+    const result = await applyApprovedBatch({
+      db,
+      description: 'near-full allowed',
+      operations: planned,
+      driveRoots: new Map([
+        [srcId, srcRoot],
+        [dstId, dstRoot],
+      ]),
+      chunkBytes: 1024,
+    });
+
+    expect(result.completed).toBe(1);
+    expect(result.failed).toBe(0);
+  });
+
+  it('Test B: rejects batch with informative error when bytes needed exceed usable freeBytes', async () => {
+    // Drive: 1 TB total, 100 MB free. Batch needs 200 MB.
+    // Correct formula: safetyMargin = 100MB * 0.05 = 5MB, usable = 95MB, 200 > 95 → REJECTED
+    const drives = new DriveRepo(db);
+    const srcRoot = join(dir, 'src-b');
+    const dstRoot = join(dir, 'dst-b');
+    mkdirSync(srcRoot, { recursive: true });
+    mkdirSync(dstRoot, { recursive: true });
+
+    const TB = 1_000_000_000_000;
+    const MB = 1_000_000;
+
+    const srcId = drives.upsert({
+      volumeSerial: 'V-SRC-B',
+      label: 'SRC-B',
+      currentLetter: null,
+      mountPath: null,
+      kind: 'local',
+      roles: [],
+      totalBytes: TB,
+      freeBytes: TB,
+    }).id;
+    const dstId = drives.upsert({
+      volumeSerial: 'V-DST-B',
+      label: 'DST-B',
+      currentLetter: null,
+      mountPath: null,
+      kind: 'local',
+      roles: [],
+      totalBytes: TB,
+      freeBytes: 100 * MB,
+    }).id;
+    db.prepare(
+      `INSERT INTO scans (id, drive_id, started_at, status, throttle_profile) VALUES (?, ?, ?, ?, ?)`,
+    ).run('s-b', srcId, new Date().toISOString(), 'completed', 'balanced');
+
+    const srcPath = join(srcRoot, 'toobig.bin');
+    writeFileSync(srcPath, 'x');
+    new FilesRepo(db).upsertOne({
+      driveId: srcId,
+      path: srcPath,
+      name: 'toobig.bin',
+      extension: 'bin',
+      sizeBytes: 1,
+      category: 'image',
+      sha256: 'hb',
+      mtime: '2024-01-01T00:00:00.000Z',
+      ctime: '2024-01-01T00:00:00.000Z',
+      exifDate: null,
+      dateSource: 'mtime',
+      width: null,
+      height: null,
+      durationSeconds: null,
+      ntfsFileId: null,
+      state: 'indexed',
+      scanId: 's-b',
+    });
+    const fileId = (db.prepare(`SELECT id FROM files WHERE path = ?`).get(srcPath) as { id: number }).id;
+
+    const planned: PlannedOperation[] = [
+      {
+        fileId,
+        ruleId: 'r-b',
+        sourceDriveId: srcId,
+        sourcePath: srcPath,
+        destDriveId: dstId,
+        destPath: join(dstRoot, 'toobig.bin'),
+        kind: 'cross-drive-move',
+        estimatedBytes: 200 * MB,
+      },
+    ];
+
+    await expect(
+      applyApprovedBatch({
+        db,
+        description: 'over-free-capacity',
+        operations: planned,
+        driveRoots: new Map([
+          [srcId, srcRoot],
+          [dstId, dstRoot],
+        ]),
+        chunkBytes: 1024,
+      }),
+    ).rejects.toThrow(/insufficient free space on DST-B/);
+  });
+
+  it('Test C: throws hard error when batch references an unknown destDriveId', async () => {
+    // A cross-drive op whose destDriveId is not in the drives table must
+    // throw — not silently skip — the free-space check.
+    const drives = new DriveRepo(db);
+    const srcRoot = join(dir, 'src-c');
+    const dstRoot = join(dir, 'dst-c');
+    mkdirSync(srcRoot, { recursive: true });
+    mkdirSync(dstRoot, { recursive: true });
+
+    const srcId = drives.upsert({
+      volumeSerial: 'V-SRC-C',
+      label: 'SRC-C',
+      currentLetter: null,
+      mountPath: null,
+      kind: 'local',
+      roles: [],
+      totalBytes: 1_000_000_000,
+      freeBytes: 1_000_000_000,
+    }).id;
+    db.prepare(
+      `INSERT INTO scans (id, drive_id, started_at, status, throttle_profile) VALUES (?, ?, ?, ?, ?)`,
+    ).run('s-c', srcId, new Date().toISOString(), 'completed', 'balanced');
+
+    const srcPath = join(srcRoot, 'ghost.bin');
+    writeFileSync(srcPath, 'x');
+    new FilesRepo(db).upsertOne({
+      driveId: srcId,
+      path: srcPath,
+      name: 'ghost.bin',
+      extension: 'bin',
+      sizeBytes: 1,
+      category: 'image',
+      sha256: 'hc',
+      mtime: '2024-01-01T00:00:00.000Z',
+      ctime: '2024-01-01T00:00:00.000Z',
+      exifDate: null,
+      dateSource: 'mtime',
+      width: null,
+      height: null,
+      durationSeconds: null,
+      ntfsFileId: null,
+      state: 'indexed',
+      scanId: 's-c',
+    });
+    const fileId = (db.prepare(`SELECT id FROM files WHERE path = ?`).get(srcPath) as { id: number }).id;
+
+    const planned: PlannedOperation[] = [
+      {
+        fileId,
+        ruleId: 'r-c',
+        sourceDriveId: srcId,
+        sourcePath: srcPath,
+        destDriveId: 'no-such-drive-id',
+        destPath: join(dstRoot, 'ghost.bin'),
+        kind: 'cross-drive-move',
+        estimatedBytes: 1_000,
+      },
+    ];
+
+    await expect(
+      applyApprovedBatch({
+        db,
+        description: 'unknown-drive',
+        operations: planned,
+        driveRoots: new Map([
+          [srcId, srcRoot],
+          ['no-such-drive-id', dstRoot],
+        ]),
+        chunkBytes: 1024,
+      }),
+    ).rejects.toThrow(/no-such-drive-id/);
+  });
+
   it('aborts the batch as DriveError when a cross-drive copy hits a disconnect-class errno', async () => {
     const sourceDriveId = seedDrive('SRC');
     const destDriveId = seedDrive('NAS');

--- a/packages/engine/src/organize/applier.ts
+++ b/packages/engine/src/organize/applier.ts
@@ -231,8 +231,8 @@ function assertFreeSpace(input: ApplyApprovedBatchInput): void {
   const drivesById = new Map(new DriveRepo(input.db).list().map((d) => [d.id, d]));
   for (const [driveId, bytesNeeded] of bytesPerDrive) {
     const drive = drivesById.get(driveId);
-    if (!drive) continue;
-    const safetyMargin = Math.floor(drive.totalBytes * FREE_SPACE_SAFETY_FRACTION);
+    if (!drive) throw new Error(`unknown destDriveId ${driveId} in batch`);
+    const safetyMargin = Math.floor(drive.freeBytes * FREE_SPACE_SAFETY_FRACTION);
     const usable = drive.freeBytes - safetyMargin;
     if (usable < bytesNeeded) {
       throw new Error(


### PR DESCRIPTION
## Summary

Fixes a Major formula bug in the free-space pre-flight: safety margin is now `freeBytes * 0.05` instead of `totalBytes * 0.05`. The previous formula computed an artificially huge margin on large near-full drives, rejecting batches that had room to fit.

Also hardens unknown-`driveId` handling: previously a silent `continue` skipped the check; now a hard throw surfaces the missing drive reference.

## Implementation notes

- One-line formula change, one-line `continue` → `throw` change
- Plan doc M7-T03 Step 2 had the same wrong formula and is fixed in the same commit
- Live `statfs()` check at apply time was out of scope per the issue (catalog `freeBytes` matches plan intent)

## Test plan

- [ ] Small batch on near-full disk (1 TB total, 500 MB free, 400 MB needed) — ALLOWED
- [ ] Batch exceeds usable space — REJECTED with informative error
- [ ] Unknown `driveId` — HARD ERROR (not silent skip)
- [ ] Existing applier tests continue to pass
- [ ] Lint + typecheck clean

## Out of scope

- Live `statfs()` at apply time (future enhancement)
- Other applier concerns

Closes #22