### PR TITLE
M4: Reject concurrent scans on same driveId with 409 (closes #24)

### DIFF
--- a/packages/engine/src/api/server.test.ts
+++ b/packages/engine/src/api/server.test.ts
@@ -91,6 +91,49 @@ describe('API server scans endpoint', () => {
     expect(res.status).toBe(404);
   });
 
+  it('rejects a second concurrent scan on the same driveId with 409', async () => {
+    // Use large files so the first scan is still running when the second POST fires.
+    // The idle profile sleeps between hash chunks (5 ms/chunk at 256 KB chunks), so
+    // 50 files × ~600 KB each gives roughly 50 × 3 × 5 ms = 750 ms of processing
+    // time — enough headroom to fire the second request before the first finishes.
+    const { mkdirSync, writeFileSync } = await import('node:fs');
+    const dataDir = join(dir, 'concurrent-data');
+    mkdirSync(dataDir, { recursive: true });
+    const payload = Buffer.alloc(600 * 1024, 'x');
+    for (let i = 0; i < 50; i += 1) {
+      writeFileSync(join(dataDir, `f${String(i).padStart(3, '0')}.jpg`), payload);
+    }
+
+    // Fire scan A — expect 201 and note the driveId.
+    const postA = await fetch(`http://127.0.0.1:${handle.port}/api/scans`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ rootPath: dataDir, profile: 'idle' }),
+    });
+    expect(postA.status).toBe(201);
+    const { scan: scanA } = (await postA.json()) as { scan: { id: string; driveId: string } };
+    const driveId = scanA.driveId;
+
+    // Fire scan B immediately — the same rootPath resolves to the same driveId.
+    const postB = await fetch(`http://127.0.0.1:${handle.port}/api/scans`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ rootPath: dataDir, profile: 'idle' }),
+    });
+    expect(postB.status).toBe(409);
+    const bodyB = (await postB.json()) as { error: string; driveId: string };
+    expect(bodyB.error).toBe('scan-already-running');
+    expect(bodyB.driveId).toBe(driveId);
+
+    // Let scan A finish so the afterEach cleanup is clean.
+    for (let i = 0; i < 200; i += 1) {
+      const got = await fetch(`http://127.0.0.1:${handle.port}/api/scans/${scanA.id}`);
+      const body = (await got.json()) as { scan: { status: string } };
+      if (body.scan.status === 'completed' || body.scan.status === 'cancelled') break;
+      await new Promise((r) => setTimeout(r, 50));
+    }
+  });
+
   it('starts a scan via POST /api/scans and reaches completion', async () => {
     const { mkdirSync, writeFileSync } = await import('node:fs');
     const dataDir = join(dir, 'data');

--- a/packages/engine/src/api/server.ts
+++ b/packages/engine/src/api/server.ts
@@ -97,6 +97,13 @@ export async function createServer(opts: CreateServerOptions): Promise<ServerHan
       return c.json({ error: 'either driveId+rootPaths or rootPath is required' }, 400);
     }
 
+    // Guard against concurrent scans on the same drive. If a scan is already
+    // running for this driveId, markMissing (orchestrator.ts) would flag the
+    // second scan's in-flight files as missing when the first scan finishes.
+    if (scans.hasRunning(drive.id)) {
+      return c.json({ error: 'scan-already-running', driveId: drive.id }, 409);
+    }
+
     const settings = new SettingsRepo(opts.db).load();
     // Use the process-singleton ref when provided (normal serve path), so the
     // scheduler's profile transitions reach in-flight scans.  When no ref was

--- a/packages/engine/src/catalog/scans-repo.ts
+++ b/packages/engine/src/catalog/scans-repo.ts
@@ -83,6 +83,13 @@ export class ScansRepo {
     return row ? toRecord(row) : null;
   }
 
+  hasRunning(driveId: string): boolean {
+    const row = this.db
+      .prepare(`SELECT 1 FROM scans WHERE drive_id = ? AND status = 'running' LIMIT 1`)
+      .get(driveId) as { 1: number } | undefined;
+    return row !== undefined;
+  }
+
   list(opts: { driveId?: string; limit?: number } = {}): ScanRecord[] {
     const limit = opts.limit ?? 100;
     const rows = (opts.driveId


### PR DESCRIPTION
## Summary

Fixes Major #24: two concurrent scans on the same drive could leave catalog state corrupted because the first scan's `markMissing` cleanup flagged the second scan's in-flight files as missing.

POST `/api/scans` now checks for an already-running scan on the resolved `driveId` and rejects with HTTP 409 `{ error: 'scan-already-running', driveId }` before starting.

## Implementation notes

- New helper `ScansRepo.hasRunning(driveId)` — single LIMIT 1 query on `status = 'running'`
- Check fires AFTER drive resolution but BEFORE `runScan` is invoked
- Queuing/aborting the in-flight scan is explicitly out of scope (separate enhancement)
- `markMissing` logic itself is correct for a single scan; only the guard is needed

## Test plan

- [ ] Two concurrent POST /api/scans for the same drive → second is 409 with correct body
- [ ] Existing single-scan tests pass (43 pre-existing tests all green)
- [ ] Full suite: 280 tests passing (279 baseline + 1 new)
- [ ] Lint + typecheck clean

## Test approach

The new test uses 50 × 600 KB files with the idle throttle profile (5 ms inter-chunk sleep) to keep scan A running when scan B fires immediately after. This reliably triggers the guard without mocking. Scan A is allowed to complete at the end so the test teardown is clean.

## Out of scope

- Queuing or aborting in-flight scans
- `rootPaths` (plural) input validation hardening (M6 / #26)
- Changes to `markMissing` semantics

Closes #24