### PR TITLE
M5: Walker terminates on directory cycles and depth limit (closes #25)

### DIFF
--- a/packages/engine/src/scan/walker.test.ts
+++ b/packages/engine/src/scan/walker.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, symlinkSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { walk, type WalkOptions } from './walker.js';
+import { walk, type WalkOptions, MAX_DEPTH } from './walker.js';
+import type { Logger } from '../log.js';
 
 let root: string;
 
@@ -25,6 +26,19 @@ const opts: Omit<WalkOptions, 'roots'> = {
   excluded: new Set(['Windows', 'node_modules']),
   extraExcluded: [],
 };
+
+function makeLogger(): { logger: Logger; warns: Array<{ msg: string; fields: Record<string, unknown> }> } {
+  const warns: Array<{ msg: string; fields: Record<string, unknown> }> = [];
+  const noop = () => {};
+  const logger: Logger = {
+    debug: noop,
+    info: noop,
+    warn: (msg, fields) => warns.push({ msg, fields: fields ?? {} }),
+    error: noop,
+    child: () => logger,
+  };
+  return { logger, warns };
+}
 
 describe('walk', () => {
   it('emits files matching extension allowlist', async () => {
@@ -175,5 +189,66 @@ describe('walk onEmptyDir', () => {
     // sibling empty leaves, aborting from inside the 5th callback leaves
     // exactly 5 callbacks fired.
     expect(fired).toHaveLength(5);
+  });
+});
+
+describe('walk cycle detection', () => {
+  it('terminates when a symlink loop points back to an ancestor dir, logs a warning, and still returns non-loop files', async () => {
+    // Structure: root/sub/ + root/keep.jpg + root/sub/loop -> root/
+    mkdirSync(join(root, 'sub'), { recursive: true });
+    writeFileSync(join(root, 'keep.jpg'), 'pixel');
+    // POSIX symlink pointing back to root — creates an infinite cycle
+    symlinkSync(root, join(root, 'sub', 'loop'));
+
+    const { logger, warns } = makeLogger();
+    const seen: string[] = [];
+
+    // Use a timeout to guard in case cycle detection is missing and it hangs.
+    // vitest default timeout is 5 s; a stack overflow would terminate first anyway.
+    for await (const entry of walk({ ...opts, roots: [root], log: logger })) {
+      seen.push(entry.path.replace(root, '').replace(/\\/g, '/'));
+    }
+
+    // The non-loop file must be returned.
+    expect(seen).toContain('/keep.jpg');
+
+    // A cycle-detection warning must have been logged.
+    const cycleWarn = warns.find((w) => w.msg === 'walker-cycle-detected');
+    expect(cycleWarn).toBeDefined();
+    expect(typeof cycleWarn?.fields['path']).toBe('string');
+  });
+
+  it('terminates when depth exceeds MAX_DEPTH and logs a depth-limit warning', async () => {
+    // Build a directory tree just past the limit.
+    // We use a smaller depth option to keep the test fast.
+    const TEST_DEPTH = MAX_DEPTH + 2;
+    let cur = root;
+    for (let i = 0; i < TEST_DEPTH; i++) {
+      cur = join(cur, `d${i}`);
+      mkdirSync(cur, { recursive: true });
+    }
+    // Put a file at the very bottom (should NOT be seen — it's past the limit).
+    writeFileSync(join(cur, 'deep.jpg'), 'x');
+    // Put a file at root level (SHOULD be seen).
+    writeFileSync(join(root, 'shallow.jpg'), 'y');
+
+    const { logger, warns } = makeLogger();
+    const seen: string[] = [];
+
+    for await (const entry of walk({ ...opts, roots: [root], log: logger })) {
+      seen.push(entry.path.replace(root, '').replace(/\\/g, '/'));
+    }
+
+    // The shallow file is within depth limit.
+    expect(seen).toContain('/shallow.jpg');
+    // The deeply nested file is beyond MAX_DEPTH and must not appear.
+    expect(seen).not.toContain(
+      '/' + Array.from({ length: TEST_DEPTH }, (_, i) => `d${i}`).join('/') + '/deep.jpg',
+    );
+
+    // A depth-limit warning must have been logged.
+    const depthWarn = warns.find((w) => w.msg === 'walker-depth-limit');
+    expect(depthWarn).toBeDefined();
+    expect(typeof depthWarn?.fields['depth']).toBe('number');
   });
 });

--- a/packages/engine/src/scan/walker.ts
+++ b/packages/engine/src/scan/walker.ts
@@ -1,6 +1,9 @@
-import { readdir, stat } from 'node:fs/promises';
+import { readdir, stat, realpath } from 'node:fs/promises';
 import { join, extname, basename } from 'node:path';
 import { isPathExcluded } from './exclusions.js';
+import type { Logger } from '../log.js';
+
+export const MAX_DEPTH = 64;
 
 export interface WalkOptions {
   roots: string[];
@@ -9,6 +12,7 @@ export interface WalkOptions {
   extraExcluded: readonly string[];
   signal?: AbortSignal;
   onEmptyDir?: (path: string) => void;
+  log?: Logger;
 }
 
 export interface WalkEntry {
@@ -21,9 +25,20 @@ export interface WalkEntry {
 }
 
 export async function* walk(opts: WalkOptions): AsyncIterable<WalkEntry> {
+  const visited = new Set<string>();
   for (const root of opts.roots) {
     if (opts.signal?.aborted) return;
-    yield* walkOne(root, opts, true);
+    // Resolve the root's real path once so the visited set starts with a
+    // canonical baseline (important when /tmp itself is a symlink, e.g. macOS).
+    let rootReal: string;
+    try {
+      rootReal = await realpath(root);
+    } catch {
+      opts.log?.warn('walker-realpath-error', { path: root });
+      continue;
+    }
+    visited.add(rootReal);
+    yield* walkOne(root, opts, true, 0, visited);
   }
 }
 
@@ -31,6 +46,8 @@ async function* walkOne(
   dir: string,
   opts: WalkOptions,
   isRoot: boolean,
+  depth: number,
+  visited: Set<string>,
 ): AsyncGenerator<WalkEntry, number, void> {
   if (opts.signal?.aborted) return 0;
   let entries;
@@ -49,8 +66,69 @@ async function* walkOne(
       continue;
     }
     const childPath = join(dir, childName);
-    if (entry.isDirectory()) {
-      const childYielded = yield* walkOne(childPath, opts, false);
+    // isDirectory() covers real dirs and NTFS junctions (Windows).
+    // isSymbolicLink() covers POSIX symlinks; we stat the target to determine
+    // if it resolves to a directory (and therefore needs cycle checking).
+    const isDir = entry.isDirectory();
+    const isSym = entry.isSymbolicLink();
+
+    if (isDir || isSym) {
+      // For symlinks, verify the target is a directory before descending.
+      if (isSym && !isDir) {
+        let targetStat;
+        try {
+          targetStat = await stat(childPath); // stat follows symlinks
+        } catch {
+          // Broken symlink or permission error — skip safely.
+          continue;
+        }
+        if (!targetStat.isDirectory()) {
+          // Symlink to a file — treat as a regular file candidate below.
+          const ext = extname(childName).slice(1).toLowerCase();
+          if (opts.extensions.has(ext)) {
+            yield {
+              path: childPath,
+              name: basename(childPath),
+              extension: ext,
+              sizeBytes: targetStat.size,
+              mtime: targetStat.mtime.toISOString(),
+              ctime: targetStat.ctime.toISOString(),
+            };
+            yieldedCount += 1;
+          }
+          continue;
+        }
+        // Symlink to a dir — fall through to cycle/depth checks below.
+      }
+
+      // Depth check — bail before resolving realpath for performance.
+      const childDepth = depth + 1;
+      if (childDepth > MAX_DEPTH) {
+        opts.log?.warn('walker-depth-limit', { path: childPath, depth: childDepth });
+        yieldedCount += 1; // treat as non-empty so ancestors don't misfire onEmptyDir
+        continue;
+      }
+      // Cycle detection via real path resolution (resolves NTFS junctions on
+      // Windows and POSIX symlinks alike).
+      let childReal: string;
+      try {
+        childReal = await realpath(childPath);
+      } catch {
+        // Permission denied or broken junction/symlink — skip safely.
+        opts.log?.warn('walker-realpath-error', { path: childPath });
+        yieldedCount += 1; // treat as non-empty
+        continue;
+      }
+      if (visited.has(childReal)) {
+        opts.log?.warn('walker-cycle-detected', { path: childPath, realpath: childReal });
+        yieldedCount += 1; // treat as non-empty
+        continue;
+      }
+      visited.add(childReal);
+      const childYielded = yield* walkOne(childPath, opts, false, childDepth, visited);
+      // Remove after recursion so sibling subtrees at the same real path are
+      // still visited (only ancestor cycles are suppressed).
+      visited.delete(childReal);
       yieldedCount += childYielded;
     } else if (entry.isFile()) {
       const ext = extname(childName).slice(1).toLowerCase();


### PR DESCRIPTION
## Summary

Fixes Major #25: walker recurses unconditionally on NTFS junctions (Windows primary platform). A self-referential junction crashes the scanner with a stack overflow. There was also no recursion depth limit as a backstop.

- Adds a `Set<string>` of visited real paths via `fs.promises.realpath` — resolves NTFS junctions on Windows and POSIX symlinks alike
- Adds `MAX_DEPTH = 64` as a constant backstop exported from `walker.ts`
- Cycles and depth-limit hits log a structured `warn` and are skipped; the walker continues and does not crash
- Also handles POSIX `isSymbolicLink()` → directory (stat follows the link), so the fix works correctly on Linux CI

## Implementation notes

- `fs.promises.realpath` resolves both NTFS junctions (Windows) and POSIX symlinks, so the visited-set handles both platforms
- The visited set is populated before descending and cleared after return, so sibling subtrees that share a real path are still visited — only ancestor cycles are suppressed
- `realpath` errors (e.g., permission denied on a broken junction) are caught, logged as `walker-realpath-error`, and skipped without crashing
- Symlinks to files (not directories) are treated as regular file candidates with the existing extension filter

## Test plan

- [x] Symlink loop terminates with `walker-cycle-detected` warning logged
- [x] Depth-limit hit terminates with `walker-depth-limit` warning logged
- [x] Non-cyclic, in-depth-limit walks: 8 existing tests pass unchanged
- [x] Full suite: 282 tests pass (280 baseline + 2 new)
- [x] Lint clean
- [x] Typecheck clean

## Out of scope

- POSIX symlinks pointing to files (handled correctly as file candidates)
- Walker performance optimization

Closes #25