### PR TITLE
M6: Harden API input validation (closes #26)

### DIFF
--- a/packages/engine/src/api/server.test.ts
+++ b/packages/engine/src/api/server.test.ts
@@ -1967,3 +1967,243 @@ describe('ThrottleManagerRef singleton: mid-scan profile change', () => {
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// Sub-fix A: Array.isArray guards on POST endpoints
+// ---------------------------------------------------------------------------
+
+describe('Array.isArray guards — /api/duplicates/apply', () => {
+  it('returns 400 when body.operations is null', async () => {
+    const res = await fetch(`http://127.0.0.1:${handle.port}/api/duplicates/apply`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ operations: null }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('operations must be an array');
+  });
+
+  it('returns 400 when body.operations is missing', async () => {
+    const res = await fetch(`http://127.0.0.1:${handle.port}/api/duplicates/apply`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('operations must be an array');
+  });
+});
+
+describe('Array.isArray guards — /api/quarantine/restore', () => {
+  it('returns 400 when body.quarantineIds is null', async () => {
+    const res = await fetch(`http://127.0.0.1:${handle.port}/api/quarantine/restore`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ quarantineIds: null }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('quarantineIds must be an array');
+  });
+
+  it('returns 400 when body.quarantineIds is missing', async () => {
+    const res = await fetch(`http://127.0.0.1:${handle.port}/api/quarantine/restore`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('quarantineIds must be an array');
+  });
+});
+
+describe('Array.isArray guards — /api/organize/apply', () => {
+  it('returns 400 when body.operations is null', async () => {
+    const res = await fetch(`http://127.0.0.1:${handle.port}/api/organize/apply`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ operations: null }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('operations must be an array');
+  });
+
+  it('returns 400 when body.operations is missing', async () => {
+    const res = await fetch(`http://127.0.0.1:${handle.port}/api/organize/apply`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('operations must be an array');
+  });
+});
+
+describe('Array.isArray guards — /api/organize/auto-apply', () => {
+  it('returns 400 when body.operations is null', async () => {
+    const res = await fetch(`http://127.0.0.1:${handle.port}/api/organize/auto-apply`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ operations: null }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('operations must be an array');
+  });
+
+  it('returns 400 when body.operations is missing', async () => {
+    const res = await fetch(`http://127.0.0.1:${handle.port}/api/organize/auto-apply`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('operations must be an array');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Sub-fix B: scan-null race — POST /api/scans always returns a valid scan
+// ---------------------------------------------------------------------------
+
+describe('scan-null race — POST /api/scans returns a valid scan ID', () => {
+  it('response always contains a valid scan object, not null', async () => {
+    const { mkdirSync, writeFileSync } = await import('node:fs');
+    const dataDir = join(dir, 'race-check');
+    mkdirSync(dataDir, { recursive: true });
+    writeFileSync(join(dataDir, 'img.jpg'), 'pixel');
+
+    const post = await fetch(`http://127.0.0.1:${handle.port}/api/scans`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ rootPath: dataDir, profile: 'idle' }),
+    });
+    expect(post.status).toBe(201);
+    const body = (await post.json()) as { scan: { id: string; status: string } | null };
+    // scan must never be null — this is the core assertion for the race fix
+    expect(body.scan).not.toBeNull();
+    expect(typeof body.scan!.id).toBe('string');
+    expect(body.scan!.id.length).toBeGreaterThan(0);
+
+    // Wait for completion so afterEach teardown is clean
+    for (let i = 0; i < 50; i += 1) {
+      const got = await fetch(`http://127.0.0.1:${handle.port}/api/scans/${body.scan!.id}`);
+      const r = (await got.json()) as { scan: { status: string } };
+      if (r.scan.status === 'completed') break;
+      await new Promise((r2) => setTimeout(r2, 50));
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Sub-fix C: rootPaths (plural) path confinement
+// ---------------------------------------------------------------------------
+
+describe('rootPaths confinement — POST /api/scans', () => {
+  it('returns 400 with path-not-confined when rootPaths contains a path outside any drive', async () => {
+    const { DriveRepo } = await import('../drives/repo.js');
+    const drive = new DriveRepo(db).upsert({
+      volumeSerial: 'CONF-A',
+      label: 'CONF-A',
+      currentLetter: null,
+      mountPath: join(dir, 'drive-a'),
+      kind: 'local',
+      roles: [],
+      totalBytes: 1,
+      freeBytes: 1,
+    });
+
+    const res = await fetch(`http://127.0.0.1:${handle.port}/api/scans`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        driveId: drive.id,
+        rootPaths: ['/some/path/outside/any/drive'],
+      }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string; path: string };
+    expect(body.error).toBe('path-not-confined');
+    expect(body.path).toBe('/some/path/outside/any/drive');
+  });
+
+  it('returns 400 when any rootPath in the batch is outside the drive (whole-batch rejection)', async () => {
+    const { mkdirSync, writeFileSync } = await import('node:fs');
+    const { DriveRepo } = await import('../drives/repo.js');
+    const mountPath = join(dir, 'drive-b');
+    mkdirSync(mountPath, { recursive: true });
+    writeFileSync(join(mountPath, 'ok.jpg'), 'ok');
+
+    const drive = new DriveRepo(db).upsert({
+      volumeSerial: 'CONF-B',
+      label: 'CONF-B',
+      currentLetter: null,
+      mountPath,
+      kind: 'local',
+      roles: [],
+      totalBytes: 1,
+      freeBytes: 1,
+    });
+
+    const res = await fetch(`http://127.0.0.1:${handle.port}/api/scans`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        driveId: drive.id,
+        rootPaths: [mountPath, '/tmp/outside'],
+      }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string; path: string };
+    expect(body.error).toBe('path-not-confined');
+    expect(body.path).toBe('/tmp/outside');
+  });
+
+  it('succeeds (201) when all rootPaths are under the registered drive mountPath', async () => {
+    const { mkdirSync, writeFileSync } = await import('node:fs');
+    const { DriveRepo } = await import('../drives/repo.js');
+    const mountPath = join(dir, 'drive-c');
+    const subDir = join(mountPath, 'sub');
+    mkdirSync(subDir, { recursive: true });
+    writeFileSync(join(subDir, 'ok.jpg'), 'ok');
+
+    const drive = new DriveRepo(db).upsert({
+      volumeSerial: 'CONF-C',
+      label: 'CONF-C',
+      currentLetter: null,
+      mountPath,
+      kind: 'local',
+      roles: [],
+      totalBytes: 1,
+      freeBytes: 1,
+    });
+
+    const res = await fetch(`http://127.0.0.1:${handle.port}/api/scans`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        driveId: drive.id,
+        rootPaths: [subDir],
+        profile: 'idle',
+      }),
+    });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { scan: { id: string } | null };
+    expect(body.scan).not.toBeNull();
+    expect(typeof body.scan!.id).toBe('string');
+
+    // Wait for completion so afterEach teardown is clean
+    for (let i = 0; i < 50; i += 1) {
+      const got = await fetch(`http://127.0.0.1:${handle.port}/api/scans/${body.scan!.id}`);
+      const r = (await got.json()) as { scan: { status: string } };
+      if (r.scan.status === 'completed') break;
+      await new Promise((r2) => setTimeout(r2, 50));
+    }
+  });
+});

--- a/packages/engine/src/api/server.ts
+++ b/packages/engine/src/api/server.ts
@@ -92,6 +92,17 @@ export async function createServer(opts: CreateServerOptions): Promise<ServerHan
       if (!body.rootPaths || body.rootPaths.length === 0) {
         return c.json({ error: 'rootPaths required when starting from existing driveId' }, 400);
       }
+      // Sub-fix C: resolve each path and verify it is under the drive's mountPath.
+      // If mountPath is not recorded for the drive, skip the confinement check.
+      if (drive.mountPath) {
+        const mountPath = resolve(drive.mountPath);
+        for (const p of body.rootPaths) {
+          const resolved = resolve(p);
+          if (resolved !== mountPath && !resolved.startsWith(mountPath + '/')) {
+            return c.json({ error: 'path-not-confined', path: p }, 400);
+          }
+        }
+      }
       roots = body.rootPaths;
     } else {
       return c.json({ error: 'either driveId+rootPaths or rootPath is required' }, 400);
@@ -119,6 +130,10 @@ export async function createServer(opts: CreateServerOptions): Promise<ServerHan
     const mediainfoPath = body.mediainfoPath ?? '';
     const controller = new AbortController();
     let registeredId: string | null = null;
+    // Sub-fix B: resolve a promise the moment onStart fires so we capture
+    // registeredId without relying on a hardcoded sleep.
+    let onStartResolve: () => void;
+    const onStartFired = new Promise<void>((res) => { onStartResolve = res; });
     const promise = runScan({
       db: opts.db,
       driveId: drive.id,
@@ -132,6 +147,7 @@ export async function createServer(opts: CreateServerOptions): Promise<ServerHan
       onStart: (scanId) => {
         registeredId = scanId;
         activeScans.set(scanId, controller);
+        onStartResolve();
       },
     });
     promise
@@ -149,12 +165,9 @@ export async function createServer(opts: CreateServerOptions): Promise<ServerHan
       .finally(() => {
         if (registeredId) activeScans.delete(registeredId);
       });
-    await new Promise((r) => setTimeout(r, 50));
-    const recentRow = opts.db
-      .prepare(`SELECT id FROM scans WHERE drive_id = ? ORDER BY started_at DESC LIMIT 1`)
-      .get(drive.id) as { id: string } | undefined;
-    const recent = recentRow ? scans.findById(recentRow.id) : null;
-    return c.json({ scan: recent }, 201);
+    await onStartFired;
+    const scan = scans.findById(registeredId!);
+    return c.json({ scan }, 201);
   });
 
   app.get('/api/scans', (c) => {
@@ -310,6 +323,9 @@ export async function createServer(opts: CreateServerOptions): Promise<ServerHan
       operations: DedupeOperation[];
       driveRoots?: Record<string, string>;
     };
+    if (!Array.isArray(body.operations)) {
+      return c.json({ error: 'operations must be an array' }, 400);
+    }
     const merged = mergeDriveRoots(drives, body.driveRoots ?? {});
     const result = await applyDedupe({
       db: opts.db,
@@ -349,6 +365,9 @@ export async function createServer(opts: CreateServerOptions): Promise<ServerHan
       quarantineIds: number[];
       driveRoots?: Record<string, string>;
     };
+    if (!Array.isArray(body.quarantineIds)) {
+      return c.json({ error: 'quarantineIds must be an array' }, 400);
+    }
     const driveRoots = mergeDriveRoots(drives, body.driveRoots ?? {});
     const rootLookup = (driveId: string): string | undefined => driveRoots.get(driveId);
     const errors: string[] = [];
@@ -531,6 +550,9 @@ export async function createServer(opts: CreateServerOptions): Promise<ServerHan
       operations: PlannedOperation[];
       driveRoots?: Record<string, string>;
     };
+    if (!Array.isArray(body.operations)) {
+      return c.json({ error: 'operations must be an array' }, 400);
+    }
     try {
       const result = await autoApply({
         db: opts.db,
@@ -562,6 +584,9 @@ export async function createServer(opts: CreateServerOptions): Promise<ServerHan
       dryRun?: boolean;
       removeEmptySourceDirs?: boolean;
     };
+    if (!Array.isArray(body.operations)) {
+      return c.json({ error: 'operations must be an array' }, 400);
+    }
     try {
       const result = await applyApprovedBatch({
         db: opts.db,


### PR DESCRIPTION
## Summary

Three bundled API hardening fixes in `packages/engine/src/api/server.ts`:

- **Array.isArray guards** on 4 POST endpoints — `null`/missing array fields now produce a structured 400 instead of an unstructured 500. Affected: `/api/duplicates/apply`, `/api/quarantine/restore`, `/api/organize/apply`, `/api/organize/auto-apply`.
- **scan-null race eliminated** — captures `registeredId` from `runScan`'s `onStart` callback via a `Promise` that resolves the moment `onStart` fires, replacing the previous 50ms sleep + DB re-query which could return `{ scan: null }` on slow disks/runners.
- **rootPaths confinement** — plural form now mirrors the singular form's path resolution + drive-mount check. Paths outside the drive's `mountPath` return 400 with the offending path. Drives with no recorded `mountPath` are exempt for backward compatibility.

## Test plan

- [ ] `/api/duplicates/apply`: null body → 400 `operations must be an array`; missing field → 400
- [ ] `/api/quarantine/restore`: null body → 400 `quarantineIds must be an array`; missing field → 400
- [ ] `/api/organize/apply`: null body → 400 `operations must be an array`; missing field → 400
- [ ] `/api/organize/auto-apply`: null body → 400 `operations must be an array`; missing field → 400
- [ ] POST `/api/scans` always returns a valid scan object with an ID, never `{ scan: null }`
- [ ] POST `/api/scans` with `rootPaths` outside any registered drive mountPath → 400 `path-not-confined` with offending path
- [ ] POST `/api/scans` with partially-invalid `rootPaths` → 400 (whole-batch rejection)
- [ ] POST `/api/scans` with all-valid `rootPaths` → 201 success
- [ ] Existing 282 baseline tests still pass; lint + typecheck clean

## Out of scope

- Global Hono error handler for JSON parse failures
- PUT /api/settings validation
- WebSocket / SSE delivery (F1)

Closes #26