### PR TITLE
M7: Update catalog after partial cross-drive undo failure (closes #27)

### DIFF
--- a/packages/engine/src/organize/undo.test.ts
+++ b/packages/engine/src/organize/undo.test.ts
@@ -322,12 +322,15 @@ describe('undoBatch', () => {
     expect(qRow).toBeDefined();
     expect(existsSync(qRow!.quarantinePath)).toBe(true);
 
-    // Catalog still points at dest (unchanged from the original move).
+    // After re-quarantine, catalog must reflect reality: state='quarantined',
+    // path pointing at the new quarantine location — NOT the stale destPath.
     const file = db
       .prepare(`SELECT path, drive_id AS driveId, state FROM files WHERE id = ?`)
       .get(fileId) as { path: string; driveId: string; state: string };
-    expect(file.path).toBe(destPath);
-    expect(file.driveId).toBe(destDriveId);
+    expect(file.state).toBe('quarantined');
+    // The path must be the new quarantine path (under sourceRoot), not destPath.
+    expect(file.path).not.toBe(destPath);
+    expect(file.path).toContain('_FileOrganizer_quarantine');
 
     // The failed undo op carries a descriptive error message.
     const failedOp = db
@@ -338,5 +341,98 @@ describe('undoBatch', () => {
       .get(undo.undoBatchId) as { errorMessage: string | null } | undefined;
     expect(failedOp).toBeDefined();
     expect(failedOp!.errorMessage).toMatch(/could not remove dest/);
+  });
+
+  it('reverseCompletedViaExisting: restores source from quarantine, dest stays intact', async () => {
+    // When the dest already had identical content, moveCrossDrive produces
+    // completed-via-existing: source is quarantined, dest untouched.
+    // undoBatch must restore the source file and mark files.state='indexed'.
+    const sourceDriveId = seedDrive('SRC2');
+    const destDriveId = seedDrive('DST2');
+    seedScan(sourceDriveId);
+    const ruleId = seedRule();
+    const sourceRoot = resolve(dir, 'SRC2');
+    const destRoot = resolve(dir, 'DST2');
+    const sourcePath = resolve(sourceRoot, 'b.jpg');
+    const destPath = resolve(destRoot, 'Photos', 'b.jpg');
+    const content = 'identical-content';
+    const fileId = seedFile(sourceDriveId, sourcePath, content);
+
+    // Pre-create dest with the same content so resolveCollision picks same-content.
+    mkdirSync(resolve(destPath, '..'), { recursive: true });
+    writeFileSync(destPath, content);
+
+    const apply = await applyApprovedBatch({
+      db,
+      description: 'forward-via-existing',
+      operations: [
+        plannedOp(
+          fileId,
+          ruleId,
+          'cross-drive-move',
+          sourceDriveId,
+          sourcePath,
+          destDriveId,
+          destPath,
+        ),
+      ],
+      driveRoots: new Map([
+        [sourceDriveId, sourceRoot],
+        [destDriveId, destRoot],
+      ]),
+      chunkBytes: 64 * 1024,
+    });
+
+    // After apply: source was quarantined (not at original path), dest still present.
+    expect(existsSync(sourcePath)).toBe(false);
+    expect(existsSync(destPath)).toBe(true);
+    const preUndoFile = db
+      .prepare(`SELECT state FROM files WHERE id = ?`)
+      .get(fileId) as { state: string };
+    expect(preUndoFile.state).toBe('quarantined');
+
+    // Verify a quarantine row exists.
+    const qBefore = db
+      .prepare(
+        `SELECT id FROM quarantine WHERE original_path = ? AND batch_id = ? ORDER BY id DESC LIMIT 1`,
+      )
+      .get(sourcePath, apply.batchId) as { id: number } | undefined;
+    expect(qBefore).toBeDefined();
+
+    const undo = await undoBatch({
+      db,
+      batchId: apply.batchId,
+      driveRoots: new Map([
+        [sourceDriveId, sourceRoot],
+        [destDriveId, destRoot],
+      ]),
+    });
+
+    expect(undo.reverted).toBe(1);
+    expect(undo.skipped).toBe(0);
+    expect(undo.errors).toHaveLength(0);
+
+    // Source file is back at its original path with correct content.
+    expect(existsSync(sourcePath)).toBe(true);
+    expect(readFileSync(sourcePath, 'utf8')).toBe(content);
+
+    // Dest file is still present (it was never the source's copy).
+    expect(existsSync(destPath)).toBe(true);
+
+    // Catalog: state='indexed', path unchanged.
+    const file = db
+      .prepare(`SELECT path, drive_id AS driveId, state FROM files WHERE id = ?`)
+      .get(fileId) as { path: string; driveId: string; state: string };
+    expect(file.state).toBe('indexed');
+    expect(file.path).toBe(sourcePath);
+    expect(file.driveId).toBe(sourceDriveId);
+
+    // Quarantine row deleted after restore.
+    const qAfter = db
+      .prepare(
+        `SELECT id FROM quarantine WHERE original_path = ? AND batch_id = ? ORDER BY id DESC LIMIT 1`,
+      )
+      .get(sourcePath, apply.batchId) as { id: number } | undefined;
+    expect(qAfter).toBeUndefined();
   });
 });

--- a/packages/engine/src/organize/undo.ts
+++ b/packages/engine/src/organize/undo.ts
@@ -191,7 +191,7 @@ async function reverseCrossDriveMove(
   } catch (err) {
     const reason = (err as Error).message;
     try {
-      quarantineFile({
+      const rollback = quarantineFile({
         db: opts.db,
         batchId: op.batchId,
         driveId: op.sourceDriveId,
@@ -201,6 +201,21 @@ async function reverseCrossDriveMove(
         sizeBytes: qSnapshot.originalSize,
         mtime: qSnapshot.originalMtime,
       });
+      // Update catalog to reflect the re-quarantined reality so the reconciler
+      // can reason about this file without manual SQL (spec §12.3).
+      try {
+        opts.db
+          .prepare(`UPDATE files SET state = 'quarantined', path = ? WHERE id = ?`)
+          .run(rollback.quarantinePath, op.fileId);
+      } catch (catalogErr) {
+        // A secondary DB failure must not mask the original unlink error; log and
+        // continue so the outer throw surfaces the real cause to the caller.
+        console.error('undo-catalog-update-failed', {
+          op_id: op.id,
+          file_id: op.fileId,
+          error: (catalogErr as Error).message,
+        });
+      }
     } catch (rollbackErr) {
       throw new Error(
         `could not remove dest at ${op.destPath} after restoring source; rollback failed: ${(rollbackErr as Error).message} (original: ${reason})`,


### PR DESCRIPTION
## Summary

Fixes Major #27: when a cross-drive undo partially failed (restore succeeded, dest unlink threw, source re-quarantined), the catalog row was left in `state='moved'` pointing at the now-stale `destPath` — invisible to the reconciler and impossible to surface without manual SQL, violating spec §12.3 "no state requiring SQL surgery".

The catch block now captures the `QuarantineResult` from the re-quarantine call and updates `files.state='quarantined'` and `files.path=quarantinePath` before re-throwing the original error.

Also adds the missing integration test for `reverseCompletedViaExisting` — that undo path had zero coverage. The function was confirmed correct; only the tests were missing.

## Implementation notes

- `quarantineFile` already returns `{ quarantineId, quarantinePath }` — just needed to capture it
- Catalog update is in its own nested try/catch — a secondary DB failure logs via `console.error` but does not mask the original unlink error; the caller still receives the real cause
- Spec §12.3 "no SQL surgery" invariant restored
- `reverseCompletedViaExisting` confirmed correct: `files.path` is never changed during `completed-via-existing` (quarantine keeps `original_path` = source path), so only `state='indexed'` update is needed on undo

## Test plan

- [x] Updated test: partial undo failure now asserts `files.state='quarantined'` and `files.path` under `_FileOrganizer_quarantine` (not the stale `destPath`)
- [x] New test: `reverseCompletedViaExisting` happy path — source restored, dest intact, quarantine row deleted, `state='indexed'`
- [x] All existing undo tests pass (6 total, up from 5)
- [x] Full suite: 295 passing (up from 294 baseline)
- [x] Lint clean
- [x] Typecheck clean

## Out of scope

- Reconciler scope expansion (already done in B1 / #19)
- Any change to the normal-success undo path

Closes #27