### PR TITLE
M8: UI resilience — offline indicator, AbortController, poll recovery (closes #28)

### DIFF
--- a/packages/ui/src/api/client.test.ts
+++ b/packages/ui/src/api/client.test.ts
@@ -29,4 +29,46 @@ describe('ApiClient', () => {
     const client = new ApiClient({ baseUrl: 'http://localhost:1234' });
     await expect(client.listDrives()).rejects.toThrow(/500/);
   });
+
+  describe('listDuplicates AbortSignal plumbing', () => {
+    it('passes the signal to fetch when provided', async () => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ groups: [], operations: [], total: 0, hasMore: false }),
+      });
+      vi.stubGlobal('fetch', fetchMock);
+      const client = new ApiClient({ baseUrl: 'http://localhost:1234' });
+      const controller = new AbortController();
+      await client.listDuplicates({ signal: controller.signal });
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining('/api/duplicates'),
+        expect.objectContaining({ signal: controller.signal }),
+      );
+    });
+
+    it('does NOT include signal key when no signal is passed', async () => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ groups: [], operations: [], total: 0, hasMore: false }),
+      });
+      vi.stubGlobal('fetch', fetchMock);
+      const client = new ApiClient({ baseUrl: 'http://localhost:1234' });
+      await client.listDuplicates();
+      const init = fetchMock.mock.calls[0]?.[1] as RequestInit | undefined;
+      expect(init ?? {}).not.toHaveProperty('signal');
+    });
+
+    it('rejects with AbortError when the signal is already aborted before the call', async () => {
+      // Simulate fetch throwing DOMException(AbortError) on an aborted signal.
+      vi.stubGlobal('fetch', vi.fn().mockRejectedValue(
+        Object.assign(new Error('aborted'), { name: 'AbortError' }),
+      ));
+      const client = new ApiClient({ baseUrl: 'http://localhost:1234' });
+      const controller = new AbortController();
+      controller.abort();
+      await expect(client.listDuplicates({ signal: controller.signal })).rejects.toMatchObject({
+        name: 'AbortError',
+      });
+    });
+  });
 });

--- a/packages/ui/src/api/client.ts
+++ b/packages/ui/src/api/client.ts
@@ -121,12 +121,14 @@ export class ApiClient {
     minSize?: number;
     limit?: number;
     offset?: number;
+    signal?: AbortSignal;
   } = {}): Promise<DedupePlanResponse> {
     const minSize = input.minSize ?? 1;
     const limit = input.limit ?? 50;
     const offset = input.offset ?? 0;
     return this.get<DedupePlanResponse>(
       `/api/duplicates?minSize=${minSize}&limit=${limit}&offset=${offset}`,
+      input.signal,
     );
   }
 
@@ -473,8 +475,10 @@ export class ApiClient {
     return this.opts.baseUrl;
   }
 
-  private async get<T>(path: string): Promise<T> {
-    const res = await fetch(`${this.opts.baseUrl}${path}`, { method: 'GET' });
+  private async get<T>(path: string, signal?: AbortSignal): Promise<T> {
+    const init: RequestInit = { method: 'GET' };
+    if (signal != null) init.signal = signal;
+    const res = await fetch(`${this.opts.baseUrl}${path}`, init);
     if (!res.ok) {
       const body = await res.text();
       throw new Error(`API ${path} failed: ${res.status} ${body}`);

--- a/packages/ui/src/app.backend-status.test.ts
+++ b/packages/ui/src/app.backend-status.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Unit tests for the backend-reachability tracking logic (Sub-fix A).
+ *
+ * The logic in app.tsx is: after OFFLINE_THRESHOLD consecutive failures the
+ * offline indicator is shown; a single success resets the counter. We test
+ * this as a pure state-machine so we can reason about it without mounting
+ * the full App component (which would require router, keyboard shortcuts, etc.).
+ */
+import { describe, it, expect } from 'vitest';
+
+const OFFLINE_THRESHOLD = 3;
+
+/**
+ * Pure model of the consecutive-failure counter.
+ * Returns { reachable, failures } after applying `events` (true = success, false = failure).
+ */
+function runBackendStatusMachine(events: boolean[]): { reachable: boolean; failures: number } {
+  let failures = 0;
+  let reachable = true;
+
+  for (const success of events) {
+    if (success) {
+      failures = 0;
+      reachable = true;
+    } else {
+      failures += 1;
+      if (failures >= OFFLINE_THRESHOLD) {
+        reachable = false;
+      }
+    }
+  }
+
+  return { reachable, failures };
+}
+
+describe('backend status machine (app.tsx Sub-fix A)', () => {
+  it('starts reachable with zero failures', () => {
+    expect(runBackendStatusMachine([])).toEqual({ reachable: true, failures: 0 });
+  });
+
+  it('stays reachable after fewer than threshold failures', () => {
+    const result = runBackendStatusMachine([false, false]);
+    expect(result.reachable).toBe(true);
+    expect(result.failures).toBe(2);
+  });
+
+  it('goes offline exactly at the threshold', () => {
+    const result = runBackendStatusMachine([false, false, false]);
+    expect(result.reachable).toBe(false);
+    expect(result.failures).toBe(3);
+  });
+
+  it('stays offline past the threshold', () => {
+    const result = runBackendStatusMachine([false, false, false, false]);
+    expect(result.reachable).toBe(false);
+    expect(result.failures).toBe(4);
+  });
+
+  it('recovers immediately on a single success after being offline', () => {
+    const result = runBackendStatusMachine([false, false, false, true]);
+    expect(result.reachable).toBe(true);
+    expect(result.failures).toBe(0);
+  });
+
+  it('resets the counter after a success, so failures restart from zero', () => {
+    // 2 failures → success (counter resets) → 2 more failures: still reachable
+    const result = runBackendStatusMachine([false, false, true, false, false]);
+    expect(result.reachable).toBe(true);
+    expect(result.failures).toBe(2);
+  });
+
+  it('goes offline again after recovery if enough failures accumulate', () => {
+    const result = runBackendStatusMachine([false, false, false, true, false, false, false]);
+    expect(result.reachable).toBe(false);
+    expect(result.failures).toBe(3);
+  });
+});

--- a/packages/ui/src/app.tsx
+++ b/packages/ui/src/app.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'preact/hooks';
+import { useEffect, useRef, useState } from 'preact/hooks';
 import { Router, Route } from 'preact-router';
 import type { DriveRecord, ScanRecord } from '@fileorganizer/shared';
 import { Sidebar } from './components/sidebar.js';
@@ -22,6 +22,9 @@ function pathToSection(path: string): string {
   return seg;
 }
 
+// Number of consecutive reloadGlobal failures before the offline indicator appears.
+const OFFLINE_THRESHOLD = 3;
+
 export function App() {
   useKeyboardShortcuts(defaultShortcuts());
   const api = defaultApiClient();
@@ -30,12 +33,30 @@ export function App() {
   const [scans, setScans] = useState<ScanRecord[]>([]);
   const [ruleCount, setRuleCount] = useState<number>(0);
   const [roleCount, setRoleCount] = useState<number>(0);
+  const [backendReachable, setBackendReachable] = useState<boolean>(true);
+  const consecutiveFailures = useRef(0);
 
   const reloadGlobal = () => {
-    api.listDrives().then(setDrives).catch(() => {});
-    api.listScans().then((s) => setScans(s as ScanRecord[])).catch(() => {});
-    api.listRules().then((rs) => setRuleCount(rs.length)).catch(() => {});
-    api.listRoles().then((rs) => setRoleCount(rs.length)).catch(() => {});
+    Promise.all([
+      api.listDrives(),
+      api.listScans(),
+      api.listRules(),
+      api.listRoles(),
+    ])
+      .then(([d, s, rs, ro]) => {
+        setDrives(d);
+        setScans(s as ScanRecord[]);
+        setRuleCount(rs.length);
+        setRoleCount(ro.length);
+        consecutiveFailures.current = 0;
+        if (!backendReachable) setBackendReachable(true);
+      })
+      .catch(() => {
+        consecutiveFailures.current += 1;
+        if (consecutiveFailures.current >= OFFLINE_THRESHOLD) {
+          setBackendReachable(false);
+        }
+      });
   };
 
   useEffect(() => {
@@ -56,7 +77,7 @@ export function App() {
         roleCount={roleCount}
       />
       <div style={{ flex: 1, display: 'flex', flexDirection: 'column', minWidth: 0, minHeight: 0 }}>
-        <TopBar section={section} drives={drives} />
+        <TopBar section={section} drives={drives} backendReachable={backendReachable} />
         <div style={{ flex: 1, minHeight: 0, overflow: 'hidden' }}>
           <Router onChange={(e) => setSection(pathToSection(e.url))}>
             <Route path="/" component={Dashboard} />

--- a/packages/ui/src/components/topbar.tsx
+++ b/packages/ui/src/components/topbar.tsx
@@ -5,9 +5,10 @@ import { driveLetter, fillPercent } from '../lib/format.js';
 interface TopBarProps {
   section: string;
   drives: DriveRecord[];
+  backendReachable?: boolean;
 }
 
-export function TopBar({ section, drives }: TopBarProps) {
+export function TopBar({ section, drives, backendReachable = true }: TopBarProps) {
   const sectionLabel = section ? section.charAt(0).toUpperCase() + section.slice(1) : 'Dashboard';
   return (
     <div
@@ -28,6 +29,33 @@ export function TopBar({ section, drives }: TopBarProps) {
         <Icon name="chevron" size={10} />
         <span style={{ color: 'var(--fg-0)' }}>{sectionLabel}</span>
       </div>
+      {!backendReachable && (
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 5,
+            padding: '2px 8px',
+            borderRadius: 3,
+            background: 'oklch(0.25 0.06 25)',
+            border: '1px solid var(--danger)',
+            fontSize: 10.5,
+            color: 'var(--danger)',
+          }}
+          title="The engine is not responding. Data shown may be stale."
+        >
+          <span
+            style={{
+              width: 6,
+              height: 6,
+              borderRadius: '50%',
+              background: 'var(--danger)',
+              flexShrink: 0,
+            }}
+          />
+          engine offline
+        </div>
+      )}
       <div style={{ flex: 1 }} />
       <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
         {drives.slice(0, 8).map((d) => {

--- a/packages/ui/src/routes/duplicates.tsx
+++ b/packages/ui/src/routes/duplicates.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'preact/hooks';
+import { useCallback, useEffect, useRef, useState } from 'preact/hooks';
 import type { RoutableProps } from 'preact-router';
 import type { DriveRecord } from '@fileorganizer/shared';
 import {
@@ -56,16 +56,27 @@ export function Duplicates(_props: DuplicatesProps) {
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const loadingRef = useRef(false);
   const initialLoadRef = useRef(false);
+  // Each loadPage call gets its own AbortController. When a new call starts,
+  // the previous in-flight request is aborted so stale responses never overwrite
+  // state from a newer minSize filter selection.
+  const abortRef = useRef<AbortController | null>(null);
 
-  const loadPage = async (offset: number, reset: boolean) => {
-    if (loadingRef.current) return;
+  const loadPage = useCallback(async (offset: number, reset: boolean) => {
+    if (!reset && loadingRef.current) return;
+    // Abort any in-flight request before starting a new one.
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
     loadingRef.current = true;
     setLoading(true);
     try {
       const [d, plan] = await Promise.all([
         offset === 0 ? api.listDrives() : Promise.resolve(null),
-        api.listDuplicates({ minSize, limit: PAGE_SIZE, offset }),
+        api.listDuplicates({ minSize, limit: PAGE_SIZE, offset, signal: controller.signal }),
       ]);
+      // Belt-and-suspenders: if aborted after the await, don't touch state.
+      if (controller.signal.aborted) return;
       if (d) setDrives(d);
       if (reset) {
         setGroups(plan.groups);
@@ -84,17 +95,19 @@ export function Duplicates(_props: DuplicatesProps) {
       setTotal(plan.total);
       setHasMore(plan.hasMore);
     } catch (e) {
+      // AbortError is expected when a newer loadPage call supersedes this one.
+      if ((e as Error).name === 'AbortError') return;
       setError((e as Error).message);
     } finally {
       loadingRef.current = false;
       setLoading(false);
     }
-  };
+  }, [minSize]);
 
   useEffect(() => {
     initialLoadRef.current = true;
-    loadPage(0, true);
-  }, [minSize]);
+    void loadPage(0, true);
+  }, [loadPage]);
 
   const driveById = new Map(drives.map((d) => [d.id, d]));
 
@@ -128,6 +141,7 @@ export function Duplicates(_props: DuplicatesProps) {
     if (dist < 240) {
       void loadPage(groups.length, false);
     }
+
   };
 
   const onApprove = async () => {

--- a/packages/ui/src/routes/scans.tsx
+++ b/packages/ui/src/routes/scans.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef } from 'preact/hooks';
+import { useEffect, useState } from 'preact/hooks';
 import type { RoutableProps } from 'preact-router';
 import type { DriveRecord, ScanRecord } from '@fileorganizer/shared';
 import { defaultApiClient } from '../api/client.js';
@@ -18,37 +18,28 @@ export function Scans(_props: RoutableProps) {
   const [info, setInfo] = useState<string | null>(null);
   const [starting, setStarting] = useState(false);
   const [pickerOpen, setPickerOpen] = useState(false);
-  const pollTimer = useRef<number | null>(null);
+  // Polling runs unconditionally from mount so a transient failure on first
+  // load never permanently disables live progress updates. The interval simply
+  // retries on each tick; errors are surfaced to the engine-offline indicator
+  // in the top bar via the global reloadGlobal failure counter (Sub-fix A).
+  const POLL_INTERVAL_MS = 1500;
 
   const reload = async () => {
     try {
       const [d, s] = await Promise.all([api.listDrives(), api.listScans()]);
       setDrives(d);
       setScans(s as ScanRecord[]);
-    } catch (e) {
-      setError((e as Error).message);
+    } catch {
+      // Swallow per-tick errors here; the global App-level polling (Sub-fix A)
+      // surfaces persistent engine-offline state to the user.
     }
   };
 
   useEffect(() => {
-    reload();
-    return () => {
-      if (pollTimer.current !== null) {
-        clearInterval(pollTimer.current);
-        pollTimer.current = null;
-      }
-    };
+    void reload();
+    const id = window.setInterval(() => { void reload(); }, POLL_INTERVAL_MS);
+    return () => clearInterval(id);
   }, []);
-
-  useEffect(() => {
-    const anyActive = scans.some((s) => s.status === 'running' || s.status === 'paused');
-    if (anyActive && pollTimer.current === null) {
-      pollTimer.current = window.setInterval(() => reload(), 1500);
-    } else if (!anyActive && pollTimer.current !== null) {
-      clearInterval(pollTimer.current);
-      pollTimer.current = null;
-    }
-  }, [scans]);
 
   const onScan = async () => {
     setError(null);


### PR DESCRIPTION
## Summary

Three bundled UI resilience fixes:

1. **Engine-offline indicator** in `app.tsx` — replaces silent `.catch()` with a visible indicator after 3 consecutive poll failures. Clears automatically when the engine comes back.
2. **AbortController in Duplicates** — rapid `minSize` changes now abort the previous in-flight `listDuplicates` request so stale responses never overwrite state from the current filter selection.
3. **Scan-page poll recovery** — the 1.5 s poll interval now starts unconditionally on mount. A transient engine error at page-load no longer permanently disables live progress updates.

## Files touched

- `packages/ui/src/app.tsx` — consecutive-failure counter + `backendReachable` state; passes prop to TopBar
- `packages/ui/src/components/topbar.tsx` — accepts `backendReachable`; renders red dot + "engine offline" label when false
- `packages/ui/src/routes/duplicates.tsx` — `abortRef` + `useCallback(loadPage, [minSize])`; catches `AbortError`
- `packages/ui/src/routes/scans.tsx` — poll starts on mount in one `useEffect`; `reload` errors are swallowed per-tick
- `packages/ui/src/api/client.ts` — `listDuplicates` accepts `signal?: AbortSignal`; `get()` private method threads it to `fetch`
- `packages/ui/src/api/client.test.ts` — 3 new tests for AbortSignal plumbing
- `packages/ui/src/app.backend-status.test.ts` — 7 new unit tests for the offline-threshold state machine

## Test results

- UI tests: 21 passing (11 pre-existing + 10 new)
- Engine tests: 295 passing (unchanged)
- Lint: clean
- Typecheck: clean

## Test plan

- [ ] Engine offline (kill engine while UI is open): indicator appears within ~10 s, clears when engine restarts
- [ ] Duplicates: rapid `minSize` changes settle on the correct value (no race visible in network tab)
- [ ] Scans: kill engine before page load, restart engine, page recovers automatically without manual reload
- [ ] Existing UI tests pass; lint + typecheck clean

## Out of scope

- Full UI test suite for route screens (M10)
- Global Hono error handler on engine side
- `defaultApiClient()` singleton refactor

Closes #28