### PR TITLE
M9: Hono CVE update + bodyLimit middleware (closes #29)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4327,9 +4327,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.15",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
-      "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
+      "version": "4.12.19",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.19.tgz",
+      "integrity": "sha512-xa3eYXYXx68XTT4hZ7dRzsXBhaq85ToSrlUJNoR0gwz/1Ap/CNwX47wfvV7pc/xWhjKVVkLT7zBJy8chhNguqQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/packages/engine/src/api/server.test.ts
+++ b/packages/engine/src/api/server.test.ts
@@ -2207,3 +2207,19 @@ describe('rootPaths confinement — POST /api/scans', () => {
     }
   });
 });
+
+describe('bodyLimit middleware', () => {
+  it('rejects a request body exceeding the 8 MB limit with HTTP 413', async () => {
+    // 9 MB > 8 MB cap — should be rejected before the route handler runs.
+    const bigBody = 'x'.repeat(9 * 1024 * 1024);
+    const res = await fetch(`http://127.0.0.1:${handle.port}/api/scans`, {
+      method: 'POST',
+      body: bigBody,
+      headers: { 'content-type': 'application/json' },
+    });
+    expect(res.status).toBe(413);
+    const json = await res.json() as { error: string; maxSize: number };
+    expect(json.error).toBe('request-too-large');
+    expect(json.maxSize).toBe(8 * 1024 * 1024);
+  });
+});

--- a/packages/engine/src/api/server.ts
+++ b/packages/engine/src/api/server.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono';
+import { bodyLimit } from 'hono/body-limit';
 import { serve } from '@hono/node-server';
 import { serveStatic } from '@hono/node-server/serve-static';
 import { createReadStream, existsSync, readdirSync, statSync } from 'node:fs';
@@ -49,6 +50,20 @@ export interface ServerHandle {
 export async function createServer(opts: CreateServerOptions): Promise<ServerHandle> {
   const app = new Hono();
   const events = new EventBus();
+
+  // 8 MB cap on all routes. GETs don't send bodies so this is a no-op for
+  // them. The largest expected mutation payload is a JSON operation list
+  // (hundreds of KB at most), so 8 MB gives a very wide safety margin while
+  // still blocking request-flooding and memory-exhaustion attacks.
+  const BODY_LIMIT = 8 * 1024 * 1024;
+  app.use(
+    '*',
+    bodyLimit({
+      maxSize: BODY_LIMIT,
+      onError: (c) => c.json({ error: 'request-too-large', maxSize: BODY_LIMIT }, 413),
+    }),
+  );
+
   const drives = new DriveRepo(opts.db);
   const scans = new ScansRepo(opts.db);
   const activeScans = new Map<string, AbortController>();


### PR DESCRIPTION
## Summary

- Updates Hono in `packages/engine` from 4.6.x to 4.12.19, patching 5 CVE advisories: GHSA-9vqf-7f2p-gf9v (bodyLimit bypass), GHSA-qp7p-654g-cw7p (CSS injection), GHSA-hm8q-7f3q-5f36 (JWT NumericDate), GHSA-p77w-8qqv-26rm (cache leakage), GHSA-69xw-7hcm-h432 (JSX tag injection)
- Adds an 8 MB `bodyLimit` middleware on all routes with a typed 413 JSON response
- Adds a test asserting the limit enforces (9 MB body → HTTP 413 with `{ error: 'request-too-large', maxSize: 8388608 }`)

## Implementation notes

- `npm audit fix --workspace=@fileorganizer/engine` resolved all runtime vulnerabilities (1 → 0)
- 8 MB cap is generous for FileOrganizer's API surface — largest expected bodies are JSON operation lists (~hundreds of KB); 8 MB provides a wide safety margin while blocking memory-exhaustion attacks
- Middleware applied globally (`*`) via `app.use()`; GETs don't send bodies so it's a no-op for them
- No existing tests needed updates — all 295 continue to pass; new test brings total to 296
- `@hono/node-ws` removal is GATED on F1 (#35) and is NOT done here

## Test plan

- [x] All 295 existing `server.test.ts` tests pass against Hono 4.12.19
- [x] New test: 9 MB POST body returns 413 with typed error `{ error: 'request-too-large', maxSize: 8388608 }`
- [x] `npm audit --omit=dev` reports 0 runtime vulnerabilities
- [x] Lint clean
- [x] Typecheck clean

## Out of scope

- Removing `@hono/node-ws` (gated on F1 #35)
- Adding SSE or WebSocket endpoints (F1)
- Other security hardening beyond the Hono CVEs

Closes #29