### PR TITLE
M11+N1: Wire ruleRole tiebreaker; prune dead code (closes #31, #32)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "@typescript-eslint/eslint-plugin": "^8.0.0",
         "@typescript-eslint/parser": "^8.0.0",
         "eslint": "^9.0.0",
-        "prettier": "^3.3.0",
         "tsx": "^4.19.0",
         "typescript": "^5.6.0",
         "vitest": "^2.1.0"
@@ -1736,32 +1735,6 @@
       "peerDependencies": {
         "@babel/core": "7.x",
         "vite": "2.x || 3.x || 4.x || 5.x || 6.x || 7.x || 8.x"
-      }
-    },
-    "node_modules/@preact/signals": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@preact/signals/-/signals-1.3.4.tgz",
-      "integrity": "sha512-TPMkStdT0QpSc8FpB63aOwXoSiZyIrPsP9Uj347KopdS6olZdAYeeird/5FZv/M1Yc1ge5qstub2o8VDbvkT4g==",
-      "license": "MIT",
-      "dependencies": {
-        "@preact/signals-core": "^1.7.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/preact"
-      },
-      "peerDependencies": {
-        "preact": "10.x"
-      }
-    },
-    "node_modules/@preact/signals-core": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.14.1.tgz",
-      "integrity": "sha512-vxPpfXqrwUe9lpjqfYNjAF/0RF/eFGeLgdJzdmIIZjpOnTmGmAB4BjWone562mJGMRP4frU6iZ6ei3PDsu52Ng==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/preact"
       }
     },
     "node_modules/@prefresh/babel-plugin": {
@@ -5432,22 +5405,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/prettier": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
-      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
     "node_modules/pretty-format": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
@@ -7179,7 +7136,6 @@
       "version": "0.0.0",
       "dependencies": {
         "@fileorganizer/shared": "*",
-        "@preact/signals": "^1.3.0",
         "preact": "^10.24.0",
         "preact-router": "^4.1.0"
       },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "tsx": "^4.19.0",
     "typescript": "^5.6.0",
     "vitest": "^2.1.0",
-    "prettier": "^3.3.0",
     "eslint": "^9.0.0",
     "@typescript-eslint/parser": "^8.0.0",
     "@typescript-eslint/eslint-plugin": "^8.0.0"

--- a/packages/engine/src/api/events.ts
+++ b/packages/engine/src/api/events.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'node:events';
 import type { ThrottleProfileName } from '@fileorganizer/shared';
 
-export interface ScanProgressEvent {
+interface ScanProgressEvent {
   type: 'scan-progress';
   scanId: string;
   filesIndexed: number;
@@ -10,7 +10,7 @@ export interface ScanProgressEvent {
   bytesProcessed: number;
 }
 
-export interface BatchStatusEvent {
+interface BatchStatusEvent {
   type: 'batch-status';
   batchId: string;
   status: string;

--- a/packages/engine/src/dedupe/planner.test.ts
+++ b/packages/engine/src/dedupe/planner.test.ts
@@ -6,6 +6,7 @@ import { openCatalog, closeCatalog, type Catalog } from '../catalog/connection.j
 import { migrate } from '../catalog/migrate.js';
 import { DriveRepo } from '../drives/repo.js';
 import { FilesRepo } from '../catalog/files-repo.js';
+import { RulesRepo } from '../rules/repo.js';
 import { planDedupe } from './planner.js';
 
 let dir: string;
@@ -63,5 +64,84 @@ describe('planDedupe', () => {
     expect(plan.operations).toHaveLength(2);
     const keeperIds = new Set(plan.operations.map((o) => o.keeperFileId));
     expect(keeperIds.size).toBe(1);
+  });
+
+  it('ruleRole tiebreaker: keeper prefers the copy on the role-matched drive (spec §8.1)', () => {
+    const driveRepo = new DriveRepo(db);
+    // roleDrive has the 'photos' role; plainDrive does not.
+    const roleDrive = driveRepo.upsert({
+      volumeSerial: 'R',
+      label: 'RoleDrive',
+      currentLetter: null,
+      kind: 'local',
+      roles: ['photos'],
+      totalBytes: 1,
+      freeBytes: 1,
+    });
+    const plainDrive = driveRepo.upsert({
+      volumeSerial: 'P',
+      label: 'PlainDrive',
+      currentLetter: null,
+      kind: 'local',
+      roles: [],
+      totalBytes: 1,
+      freeBytes: 1,
+    });
+    db.prepare(
+      `INSERT INTO scans (id, drive_id, started_at, status, throttle_profile) VALUES (?, ?, ?, ?, ?)`,
+    ).run('sr', roleDrive.id, '2024-01-01T00:00:00.000Z', 'completed', 'balanced');
+    db.prepare(
+      `INSERT INTO scans (id, drive_id, started_at, status, throttle_profile) VALUES (?, ?, ?, ?, ?)`,
+    ).run('sp', plainDrive.id, '2024-01-01T00:00:00.000Z', 'completed', 'balanced');
+
+    // Rule: images should go to the 'photos' role.
+    new RulesRepo(db).create({
+      name: 'photos-rule',
+      priority: 10,
+      match: { category: ['image'] },
+      destinationRole: 'photos',
+      destinationTemplate: 'Photos/{filename}',
+      movePolicy: 'same-drive-auto',
+      quarantinePolicy: 'default',
+    });
+
+    const files = new FilesRepo(db);
+    const seedFile = (driveId2: string, scanId2: string) => {
+      files.upsertOne({
+        driveId: driveId2,
+        path: '/photo.jpg',
+        name: 'photo.jpg',
+        extension: 'jpg',
+        sizeBytes: 500,
+        category: 'image',
+        sha256: 'dupe-hash',
+        mtime: '2024-01-01T00:00:00.000Z',
+        ctime: '2024-01-01T00:00:00.000Z',
+        exifDate: null,
+        dateSource: 'mtime',
+        width: null,
+        height: null,
+        durationSeconds: null,
+        ntfsFileId: null,
+        state: 'indexed',
+        scanId: scanId2,
+      });
+      return (db.prepare(`SELECT id FROM files WHERE drive_id = ? AND path = ?`).get(driveId2, '/photo.jpg') as { id: number }).id;
+    };
+    // Place one copy on the plain drive first (lower fileId) so that without
+    // ruleRole wired it would win the lexicographic tiebreaker, and one copy
+    // on the role-matched drive.
+    const plainFileId = seedFile(plainDrive.id, 'sp');
+    const roleFileId = seedFile(roleDrive.id, 'sr');
+
+    const plan = planDedupe(db, { minSizeBytes: 1 });
+    expect(plan.operations).toHaveLength(1);
+    const op = plan.operations[0]!;
+    // The copy on the role-matched drive must be the keeper.
+    expect(op.keeperFileId).toBe(roleFileId);
+    // The copy on the plain drive must be the one to remove.
+    expect(op.removeFileId).toBe(plainFileId);
+    // The reason should mention the role tiebreaker.
+    expect(op.reasons.some((r) => r.includes('role'))).toBe(true);
   });
 });

--- a/packages/engine/src/dedupe/planner.ts
+++ b/packages/engine/src/dedupe/planner.ts
@@ -1,6 +1,9 @@
 import { detectDuplicates, countDuplicateGroups, type DuplicateGroup } from './detect.js';
 import { scoreCopies, type DriveContext } from './scorer.js';
 import type { Catalog } from '../catalog/connection.js';
+import { RulesRepo } from '../rules/repo.js';
+import { firstMatch } from '../rules/matcher.js';
+import type { FileRecord } from '@fileorganizer/shared';
 
 export interface DedupeOperation {
   groupSha256: string;
@@ -42,12 +45,59 @@ export function planDedupe(db: Catalog, opts: PlanDedupeOptions): DedupePlan {
   for (const r of driveRows) {
     drives.set(r.id, { kind: r.kind, roles: JSON.parse(r.roles || '[]') });
   }
+  const rules = new RulesRepo(db).list();
+  const fileCache = new Map<number, FileRecord>();
+  const getFileRecord = (fileId: number): FileRecord | null => {
+    if (fileCache.has(fileId)) return fileCache.get(fileId)!;
+    const row = db
+      .prepare(`SELECT * FROM files WHERE id = ?`)
+      .get(fileId) as Record<string, unknown> | undefined;
+    if (!row) return null;
+    const rec: FileRecord = {
+      id: row['id'] as number,
+      driveId: row['drive_id'] as string,
+      path: row['path'] as string,
+      name: row['name'] as string,
+      extension: row['extension'] as string,
+      sizeBytes: row['size_bytes'] as number,
+      category: row['category'] as FileRecord['category'],
+      sha256: row['sha256'] as string,
+      mtime: row['mtime'] as string,
+      ctime: row['ctime'] as string,
+      exifDate: (row['exif_date'] as string | null) ?? null,
+      dateSource: row['date_source'] as FileRecord['dateSource'],
+      width: (row['width'] as number | null) ?? null,
+      height: (row['height'] as number | null) ?? null,
+      durationSeconds: (row['duration_seconds'] as number | null) ?? null,
+      ntfsFileId: (row['ntfs_file_id'] as string | null) ?? null,
+      state: row['state'] as FileRecord['state'],
+      lastVerifiedAt: row['last_verified_at'] as string,
+      scanId: row['scan_id'] as string,
+    };
+    fileCache.set(fileId, rec);
+    return rec;
+  };
   const operations: DedupeOperation[] = [];
   for (const group of groups) {
+    // Resolve the matched rule for any copy in the group (all copies share
+    // the same SHA256 and therefore the same category/extension, so the
+    // first resolvable copy's match is representative for the group).
+    let ruleRole: string | null = null;
+    let destinationTemplates: string[] = [];
+    for (const copy of group.copies) {
+      const file = getFileRecord(copy.fileId);
+      if (!file) continue;
+      const matchedRule = firstMatch(file, rules);
+      if (matchedRule) {
+        ruleRole = matchedRule.destinationRole ?? null;
+        destinationTemplates = [matchedRule.destinationTemplate];
+      }
+      break;
+    }
     const score = scoreCopies(group.copies, {
       drives,
-      ruleRole: null,
-      destinationTemplates: [],
+      ruleRole,
+      destinationTemplates,
     });
     for (const copy of group.copies) {
       if (copy.fileId === score.keeperFileId) continue;

--- a/packages/engine/src/log.ts
+++ b/packages/engine/src/log.ts
@@ -1,4 +1,4 @@
-export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+type LogLevel = 'debug' | 'info' | 'warn' | 'error';
 
 const LEVEL_ORDER: Record<LogLevel, number> = {
   debug: 10,

--- a/packages/engine/src/organize/planner.ts
+++ b/packages/engine/src/organize/planner.ts
@@ -12,7 +12,7 @@ import { firstMatch, matches } from '../rules/matcher.js';
 import { renderTemplate } from '../rules/template.js';
 import { resolveRole } from '../rules/role-resolver.js';
 
-export type OperationKindPlanned = 'same-drive-move' | 'cross-drive-move' | 'noop';
+type OperationKindPlanned = 'same-drive-move' | 'cross-drive-move' | 'noop';
 
 export interface PlannedOperation {
   fileId: number;
@@ -25,13 +25,13 @@ export interface PlannedOperation {
   estimatedBytes: number;
 }
 
-export interface UnresolvedRole {
+interface UnresolvedRole {
   ruleId: string;
   reason: string;
   fileCount: number;
 }
 
-export interface RuleStat {
+interface RuleStat {
   ruleId: string;
   wouldMatch: number;
   actualMatch: number;

--- a/packages/engine/src/quarantine/quarantine.ts
+++ b/packages/engine/src/quarantine/quarantine.ts
@@ -21,10 +21,6 @@ export interface QuarantineResult {
 
 const QUARANTINE_DIR = '_FileOrganizer_quarantine';
 
-export function quarantineRoot(driveRoot: string): string {
-  return join(driveRoot, QUARANTINE_DIR);
-}
-
 export function quarantineFile(input: QuarantineFileInput): QuarantineResult {
   const rel = relative(input.driveRoot, input.sourcePath);
   if (rel.startsWith('..') || rel === '') {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -12,8 +12,7 @@
   "dependencies": {
     "@fileorganizer/shared": "*",
     "preact": "^10.24.0",
-    "preact-router": "^4.1.0",
-    "@preact/signals": "^1.3.0"
+    "preact-router": "^4.1.0"
   },
   "devDependencies": {
     "vite": "^5.4.0",


### PR DESCRIPTION
## Summary

Bundles two cleanup issues into one commit:

**M11 (#31)** — Wire `ruleRole` into `planDedupe` (restoring spec §8.1's drive-role-priority tiebreaker) and remove `@preact/signals` (declared but never imported anywhere).

**N1 (#32)** — Remove `prettier` root devDep (in devDependencies but never called by any npm script), delete `quarantineRoot` function (not exported, not called), and remove `export` keyword from 5 unused exported types.

`@hono/node-ws` stays — its disposition is gated on F1 (#35).

## Decisions made

- `ruleRole`: WIRE-UP chosen — `planDedupe` now loads rules from DB, finds the first matching rule for each duplicate group's copies, and passes `matchedRule.destinationRole` as `ruleRole` to the scorer. The scorer already handled this correctly in unit tests; the production call site had hardwired `null`. Also threads `destinationTemplate` while at it.
- `@preact/signals`: REMOVED — no current imports anywhere in `packages/ui/src/`, no adoption plan.
- `@hono/node-ws`: PRESERVED — F1 (#35) hasn't decided WebSocket/SSE browser delivery yet.
- `prettier`: REMOVED — declared in root devDeps but no npm script calls it.
- `quarantineRoot`: DELETED ENTIRELY — removing `export` triggered an ESLint `no-unused-vars` error because `quarantine.ts` itself never calls the function either. `reconcile.ts` uses its own local `const quarantineRoot = join(...)`, not an import.
- `@testing-library/preact`: LEFT IN PLACE — imported in `use-keyboard.test.tsx`.
- `jsdom`: LEFT IN PLACE — configured as `environment: 'jsdom'` in `vitest.config.ts` and `vite.config.ts`.

## Test plan

- [x] `ruleRole` integration test: file with matching rule whose `destinationRole` is set → keeper is the copy on the role-matched drive, not the one with lower fileId
- [x] `npm install` after dep removals — no errors
- [x] knip re-run: `@preact/signals`, `prettier`, `quarantineRoot`, 5 unused type exports all gone from output
- [x] Engine tests: 311 pass (310 baseline + 1 new `ruleRole` integration test)
- [x] UI tests: 21 pass (baseline unchanged)
- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean

## Out of scope

- `@hono/node-ws` removal (F1 / #35)
- `createThrottleManagerRef` (knip-flagged but not listed in #32)
- New WebSocket/SSE delivery (F1)

Closes #31
Closes #32