### PR TITLE
D1+N2: README scan-resume fix; Category cast guard (closes #34, #33)

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,8 +153,8 @@ before turning it loose on a real library.
   drive priority/overflow on the Roles screen, or move some files
   manually first to make room.
 - **A scan stops with `paused` status** — open it on the Scans screen
-  and click Resume. Scans resume from the last completed directory; no
-  files are re-hashed unnecessarily.
+  and click Resume. Resume re-walks all directories; unchanged files
+  (by size+mtime) are not re-hashed.
 
 ## Architecture
 

--- a/packages/shared/src/settings.test.ts
+++ b/packages/shared/src/settings.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { categoryForExtension, DEFAULT_CATEGORY_MAP } from './settings.js';
+import { categoryForExtension, DEFAULT_CATEGORY_MAP, type CategoryMap } from './settings.js';
 
 describe('categoryForExtension', () => {
   it('matches known extensions case-insensitively', () => {
@@ -12,5 +12,10 @@ describe('categoryForExtension', () => {
   it('returns null for unknown extensions', () => {
     expect(categoryForExtension(DEFAULT_CATEGORY_MAP, 'exe')).toBeNull();
     expect(categoryForExtension(DEFAULT_CATEGORY_MAP, '')).toBeNull();
+  });
+
+  it('returns null for unknown category keys (does not silently widen)', () => {
+    const customMap: CategoryMap = { custom_kind: ['xyz'] };
+    expect(categoryForExtension(customMap, 'xyz')).toBeNull();
   });
 });

--- a/packages/shared/src/settings.ts
+++ b/packages/shared/src/settings.ts
@@ -1,3 +1,4 @@
+import { CATEGORIES } from './types.js';
 import type { Category, ThrottleProfileName } from './types.js';
 import type { ThrottleProfile, ThrottleScheduleEntry } from './throttle.js';
 
@@ -40,6 +41,7 @@ export function categoryForExtension(map: CategoryMap, extension: string): Categ
   const ext = extension.toLowerCase().replace(/^\./, '');
   for (const [cat, exts] of Object.entries(map)) {
     if (exts.includes(ext)) {
+      if (!(CATEGORIES as readonly string[]).includes(cat)) return null;
       return cat as Category;
     }
   }


### PR DESCRIPTION
## Summary

Small cleanup bundle:

**D1** — README's "scans resume from the last completed directory" claim was factually wrong; the implementation actually re-walks and skips unchanged files via size+mtime. Reworded.

**N2** — `categoryForExtension` in `shared/settings.ts` cast arbitrary map keys to the `Category` union without a runtime guard. Added a guard that returns `null` for unknown keys.

Most of D1 and N2's original scope already shipped in earlier MRs (spec §12.3 in B1, plan M7-T03 in M2, settings-repo shape drift in M1). Only the remaining items land here.

## Test plan

- [ ] README reads correctly
- [ ] `categoryForExtension` returns `null` for unknown category keys
- [ ] Existing tests pass; lint + typecheck clean

## Out of scope

- F1 decisions (#35): processPriority + WebSocket browser delivery

Closes #34
Closes #33