### PR TITLE
F1 Item 1: Remove processPriority field (closes #35)

### DIFF
--- a/docs/superpowers/plans/2026-04-25-file-organizer-implementation.md
+++ b/docs/superpowers/plans/2026-04-25-file-organizer-implementation.md
@@ -872,7 +872,6 @@ export interface ThrottleProfile {
   networkHashWorkers: number;
   readChunkBytes: number;
   interChunkSleepMs: number;
-  processPriority: 'below-normal' | 'normal' | 'high';
   maxOpenFiles: number;
 }
 
@@ -890,7 +889,6 @@ export const DEFAULT_THROTTLE_PROFILES: Record<ThrottleProfileName, ThrottleProf
     networkHashWorkers: 1,
     readChunkBytes: 256 * 1024,
     interChunkSleepMs: 5,
-    processPriority: 'below-normal',
     maxOpenFiles: 4,
   },
   balanced: {
@@ -899,7 +897,6 @@ export const DEFAULT_THROTTLE_PROFILES: Record<ThrottleProfileName, ThrottleProf
     networkHashWorkers: 1,
     readChunkBytes: 1024 * 1024,
     interChunkSleepMs: 1,
-    processPriority: 'normal',
     maxOpenFiles: 16,
   },
   'full-send': {
@@ -908,7 +905,6 @@ export const DEFAULT_THROTTLE_PROFILES: Record<ThrottleProfileName, ThrottleProf
     networkHashWorkers: 2,
     readChunkBytes: 4 * 1024 * 1024,
     interChunkSleepMs: 0,
-    processPriority: 'normal',
     maxOpenFiles: 64,
   },
 };
@@ -929,7 +925,6 @@ export interface ThrottleProfile {
   networkHashWorkers: number;
   readChunkBytes: number;
   interChunkSleepMs: number;
-  processPriority: 'below-normal' | 'normal' | 'high';
   maxOpenFiles: number;
 }
 
@@ -948,7 +943,6 @@ export function defaultThrottleProfiles(cpuCount: number): Record<ThrottleProfil
       networkHashWorkers: 1,
       readChunkBytes: 256 * 1024,
       interChunkSleepMs: 5,
-      processPriority: 'below-normal',
       maxOpenFiles: 4,
     },
     balanced: {
@@ -957,7 +951,6 @@ export function defaultThrottleProfiles(cpuCount: number): Record<ThrottleProfil
       networkHashWorkers: 1,
       readChunkBytes: 1024 * 1024,
       interChunkSleepMs: 1,
-      processPriority: 'normal',
       maxOpenFiles: 16,
     },
     'full-send': {
@@ -966,7 +959,6 @@ export function defaultThrottleProfiles(cpuCount: number): Record<ThrottleProfil
       networkHashWorkers: 2,
       readChunkBytes: 4 * 1024 * 1024,
       interChunkSleepMs: 0,
-      processPriority: 'normal',
       maxOpenFiles: 64,
     },
   };
@@ -9254,7 +9246,7 @@ export function Throttle() {
           return (
             <div key={name} style="margin-bottom:12px">
               <strong>{name}</strong>
-              <div class="muted">workers: local {p.localHashWorkers} / nas {p.networkHashWorkers} · chunk {p.readChunkBytes}B · sleep {p.interChunkSleepMs}ms · priority {p.processPriority}</div>
+              <div class="muted">workers: local {p.localHashWorkers} / nas {p.networkHashWorkers} · chunk {p.readChunkBytes}B · sleep {p.interChunkSleepMs}ms</div>
               <input type="number" min={1} max={32} value={p.localHashWorkers} onInput={(e) => {
                 const v = parseInt((e.target as HTMLInputElement).value, 10);
                 setSettings({

--- a/docs/superpowers/specs/2026-04-25-file-organizer-design.md
+++ b/docs/superpowers/specs/2026-04-25-file-organizer-design.md
@@ -254,7 +254,6 @@ Three profiles, hot-swappable mid-scan:
 | NAS hash workers | 1 | 1 | 2 |
 | Read chunk size | 256 KB | 1 MB | 4 MB |
 | Inter-chunk sleep (ms) | 5 | 1 | 0 |
-| Process priority | below normal | normal | normal |
 | Max open files | 4 | 16 | 64 |
 
 NAS workers are capped low even on `full-send` because the bottleneck is network bandwidth and concurrent reads thrash mechanical disks.

--- a/packages/shared/src/throttle.ts
+++ b/packages/shared/src/throttle.ts
@@ -6,7 +6,6 @@ export interface ThrottleProfile {
   networkHashWorkers: number;
   readChunkBytes: number;
   interChunkSleepMs: number;
-  processPriority: 'below-normal' | 'normal' | 'high';
   maxOpenFiles: number;
 }
 
@@ -25,7 +24,6 @@ export function defaultThrottleProfiles(cpuCount: number): Record<ThrottleProfil
       networkHashWorkers: 1,
       readChunkBytes: 256 * 1024,
       interChunkSleepMs: 5,
-      processPriority: 'below-normal',
       maxOpenFiles: 4,
     },
     balanced: {
@@ -34,7 +32,6 @@ export function defaultThrottleProfiles(cpuCount: number): Record<ThrottleProfil
       networkHashWorkers: 1,
       readChunkBytes: 1024 * 1024,
       interChunkSleepMs: 1,
-      processPriority: 'normal',
       maxOpenFiles: 16,
     },
     'full-send': {
@@ -43,7 +40,6 @@ export function defaultThrottleProfiles(cpuCount: number): Record<ThrottleProfil
       networkHashWorkers: 2,
       readChunkBytes: 4 * 1024 * 1024,
       interChunkSleepMs: 0,
-      processPriority: 'normal',
       maxOpenFiles: 64,
     },
   };

--- a/packages/ui/src/routes/throttle.tsx
+++ b/packages/ui/src/routes/throttle.tsx
@@ -389,21 +389,6 @@ function ProfileCard({ profile, onChange }: ProfileCardProps) {
           onInput={(e) => onChange({ maxOpenFiles: num(e) })}
         />
       </ProfileField>
-      <ProfileField label="Process priority">
-        <select
-          value={profile.processPriority}
-          onChange={(e) =>
-            onChange({
-              processPriority: (e.target as HTMLSelectElement)
-                .value as ThrottleProfile['processPriority'],
-            })
-          }
-        >
-          <option value="below-normal">below-normal</option>
-          <option value="normal">normal</option>
-          <option value="high">high</option>
-        </select>
-      </ProfileField>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

F1 (#35) decision Item 1 = **C) Remove**. The `processPriority` field on `ThrottleProfile` was typed and stored but no code ever applied OS-level priority. UI rendered the configured value giving a false impression.

Removes the field from:
- `shared/throttle.ts` — type + default profile literals
- engine throttle module(s) — any readers
- settings persistence
- UI throttle render
- spec §5.5

## F1 Item 2 explicitly out of scope

The WebSocket browser delivery decision (Item 2) is being planned separately and is NOT part of this MR. `@hono/node-ws` stays in `packages/engine/package.json` until that planning round lands a follow-up.

## Test plan

- [ ] `grep -r processPriority packages/ docs/` returns empty
- [ ] All tests pass (engine + UI + shared)
- [ ] Lint + typecheck clean

Closes #35